### PR TITLE
Patch allow-non-breakable-words on '-'

### DIFF
--- a/tests/rules/test_line_length.py
+++ b/tests/rules/test_line_length.py
@@ -78,6 +78,12 @@ class LineLengthTestCase(RuleTestCase):
                    '        # http://localhost/very/long/url\n'
                    '        comment\n'
                    '...\n', conf)
+        self.check('---\n'
+                   'this:\n'
+                   'is:\n'
+                   'another:\n'
+                   '  - https://localhost/very/very/long/url\n'
+                   '...\n', conf)
 
         conf = 'line-length: {max: 20, allow-non-breakable-words: no}'
         self.check('---\n' + 30 * 'A' + '\n', conf, problem=(2, 21))
@@ -93,4 +99,10 @@ class LineLengthTestCase(RuleTestCase):
                    '    - a:\n'
                    '        # http://localhost/very/long/url\n'
                    '        comment\n'
+                   '...\n', conf, problem=(5, 21))
+        self.check('---\n'
+                   'this:\n'
+                   'is:\n'
+                   'another:\n'
+                   '  - https://localhost/very/very/long/url\n'
                    '...\n', conf, problem=(5, 21))

--- a/yamllint/rules/line_length.py
+++ b/yamllint/rules/line_length.py
@@ -90,7 +90,7 @@ def check(conf, line):
                 start += 1
 
             if start != line.end:
-                if line.buffer[start] == '#':
+                if line.buffer[start] in ('#', '-'):
                     start += 2
 
                 if line.buffer.find(' ', start, line.end) == -1:


### PR DESCRIPTION
Hi,

I found that the allow-non-breakable-words is not working as I expected (not sure if we have the same expectations!) with long URLs preceeded by '- ' instead of '# '.

The patch implements (test included) that expectation.

HTH,
Michele

PS: I came up with the use case using yamllint on Ansible playbooks