### PR TITLE
Support comments with multiple pound signs

### DIFF
--- a/tests/rules/test_comments.py
+++ b/tests/rules/test_comments.py
@@ -52,7 +52,8 @@ class CommentsTestCase(RuleTestCase):
                    '# comment 2\n'
                    '# comment 3\n'
                    '  #  comment 3 bis\n'
-                   '  #  comment 3 ter\n', conf)
+                   '  #  comment 3 ter\n'
+                   '## comment 4\n', conf)
         self.check('---\n'
                    '#comment\n'
                    '\n'
@@ -63,7 +64,8 @@ class CommentsTestCase(RuleTestCase):
                    '# comment 2\n'
                    '#comment 3\n'
                    '  #comment 3 bis\n'
-                   '  #  comment 3 ter\n', conf,
+                   '  #  comment 3 ter\n'
+                   '## comment 4\n', conf,
                    problem1=(2, 2), problem2=(6, 13),
                    problem4=(9, 2), problem5=(10, 4))
 
@@ -105,6 +107,7 @@ class CommentsTestCase(RuleTestCase):
                    '#comment 3\n'
                    '  #comment 3 bis\n'
                    '  #  comment 3 ter\n'
+                   '## comment 4\n'
                    '\n'
                    'string: "Une longue phrase." # this is French\n', conf,
                    problem1=(2, 2),
@@ -112,7 +115,7 @@ class CommentsTestCase(RuleTestCase):
                    problem3=(6, 11), problem4=(6, 12),
                    problem5=(9, 2),
                    problem6=(10, 4),
-                   problem7=(13, 30))
+                   problem7=(14, 30))
 
     def test_empty_comment(self):
         conf = ('comments:\n'

--- a/yamllint/rules/comments.py
+++ b/yamllint/rules/comments.py
@@ -74,6 +74,7 @@ def check(conf, comment):
     if (conf['require-starting-space'] and
             comment.pointer + 1 < len(comment.buffer) and
             comment.buffer[comment.pointer + 1] != ' ' and
+            comment.buffer[comment.pointer + 1] != '#' and
             comment.buffer[comment.pointer + 1] != '\n'):
         yield LintProblem(comment.line_no, comment.column_no + 1,
                           'missing starting space in comment')


### PR DESCRIPTION
This change adds support for comments with multiple pound signs
so this example becomes valid and no longer raises lint problems:

    ---
    ## This is a section
    section1_key: value