### PR TITLE
setup.py - don't distribute tests

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(
         'Topic :: Software Development :: Testing',
     ],
 
-    packages=find_packages(),
+    packages=find_packages(exclude=['tests', 'tests.*']),
     entry_points={'console_scripts': ['yamllint=yamllint.cli:run']},
     package_data={'yamllint': ['conf/*.yaml'],
                   'tests': ['yaml-1.2-spec-examples/*']},


### PR DESCRIPTION
Found them installed in my `site-packages`, importable as `import tests` :scream:

Tested with:

```
In [2]: find_packages()
Out[2]: ['tests', 'yamllint', 'tests.rules', 'yamllint.rules']

In [3]: find_packages(exclude=['tests', 'tests.*'])
Out[3]: ['yamllint', 'yamllint.rules']
```