### PR TITLE
Add min-spaces-inside-empty, max-spaces-inside-empty to braces and brackets

### DIFF
--- a/tests/rules/test_braces.py
+++ b/tests/rules/test_braces.py
@@ -32,11 +32,19 @@ class ColonTestCase(RuleTestCase):
                    'dict7: {   a: 1, b, c: 3 }\n', conf)
 
     def test_min_spaces(self):
-        conf = 'braces: {max-spaces-inside: -1, min-spaces-inside: 0}'
+        conf = ('braces:\n'
+                '  max-spaces-inside: -1\n'
+                '  min-spaces-inside: 0\n'
+                '  max-spaces-inside-empty: -1\n'
+                '  min-spaces-inside-empty: -1\n')
         self.check('---\n'
                    'dict: {}\n', conf)
 
-        conf = 'braces: {max-spaces-inside: -1, min-spaces-inside: 1}'
+        conf = ('braces:\n'
+                '  max-spaces-inside: -1\n'
+                '  min-spaces-inside: 1\n'
+                '  max-spaces-inside-empty: -1\n'
+                '  min-spaces-inside-empty: -1\n')
         self.check('---\n'
                    'dict: {}\n', conf, problem=(2, 8))
         self.check('---\n'
@@ -52,7 +60,11 @@ class ColonTestCase(RuleTestCase):
                    '  b\n'
                    '}\n', conf)
 
-        conf = 'braces: {max-spaces-inside: -1, min-spaces-inside: 3}'
+        conf = ('braces:\n'
+                '  max-spaces-inside: -1\n'
+                '  min-spaces-inside: 3\n'
+                '  max-spaces-inside-empty: -1\n'
+                '  min-spaces-inside-empty: -1\n')
         self.check('---\n'
                    'dict: { a: 1, b }\n', conf,
                    problem1=(2, 9), problem2=(2, 17))
@@ -60,7 +72,11 @@ class ColonTestCase(RuleTestCase):
                    'dict: {   a: 1, b   }\n', conf)
 
     def test_max_spaces(self):
-        conf = 'braces: {max-spaces-inside: 0, min-spaces-inside: -1}'
+        conf = ('braces:\n'
+                '  max-spaces-inside: 0\n'
+                '  min-spaces-inside: -1\n'
+                '  max-spaces-inside-empty: -1\n'
+                '  min-spaces-inside-empty: -1\n')
         self.check('---\n'
                    'dict: {}\n', conf)
         self.check('---\n'
@@ -79,7 +95,11 @@ class ColonTestCase(RuleTestCase):
                    '  b\n'
                    '}\n', conf)
 
-        conf = 'braces: {max-spaces-inside: 3, min-spaces-inside: -1}'
+        conf = ('braces:\n'
+                '  max-spaces-inside: 3\n'
+                '  min-spaces-inside: -1\n'
+                '  max-spaces-inside-empty: -1\n'
+                '  min-spaces-inside-empty: -1\n')
         self.check('---\n'
                    'dict: {   a: 1, b   }\n', conf)
         self.check('---\n'
@@ -87,7 +107,11 @@ class ColonTestCase(RuleTestCase):
                    problem1=(2, 11), problem2=(2, 23))
 
     def test_min_and_max_spaces(self):
-        conf = 'braces: {max-spaces-inside: 0, min-spaces-inside: 0}'
+        conf = ('braces:\n'
+                '  max-spaces-inside: 0\n'
+                '  min-spaces-inside: 0\n'
+                '  max-spaces-inside-empty: -1\n'
+                '  min-spaces-inside-empty: -1\n')
         self.check('---\n'
                    'dict: {}\n', conf)
         self.check('---\n'
@@ -95,14 +119,169 @@ class ColonTestCase(RuleTestCase):
         self.check('---\n'
                    'dict: {   a: 1, b}\n', conf, problem=(2, 10))
 
-        conf = 'braces: {max-spaces-inside: 1, min-spaces-inside: 1}'
+        conf = ('braces:\n'
+                '  max-spaces-inside: 1\n'
+                '  min-spaces-inside: 1\n'
+                '  max-spaces-inside-empty: -1\n'
+                '  min-spaces-inside-empty: -1\n')
         self.check('---\n'
                    'dict: {a: 1, b, c: 3 }\n', conf, problem=(2, 8))
 
-        conf = 'braces: {max-spaces-inside: 2, min-spaces-inside: 0}'
+        conf = ('braces:\n'
+                '  max-spaces-inside: 2\n'
+                '  min-spaces-inside: 0\n'
+                '  max-spaces-inside-empty: -1\n'
+                '  min-spaces-inside-empty: -1\n')
         self.check('---\n'
                    'dict: {a: 1, b, c: 3 }\n', conf)
         self.check('---\n'
                    'dict: {  a: 1, b, c: 3 }\n', conf)
         self.check('---\n'
                    'dict: {   a: 1, b, c: 3 }\n', conf, problem=(2, 10))
+
+    def test_min_spaces_empty(self):
+        conf = ('braces:\n'
+                '  max-spaces-inside: -1\n'
+                '  min-spaces-inside: -1\n'
+                '  max-spaces-inside-empty: 0\n'
+                '  min-spaces-inside-empty: 0\n')
+        self.check('---\n'
+                   'array: {}\n', conf)
+
+        conf = ('braces:\n'
+                '  max-spaces-inside: -1\n'
+                '  min-spaces-inside: -1\n'
+                '  max-spaces-inside-empty: -1\n'
+                '  min-spaces-inside-empty: 1\n')
+        self.check('---\n'
+                   'array: {}\n', conf, problem=(2, 9))
+        self.check('---\n'
+                   'array: { }\n', conf)
+
+        conf = ('braces:\n'
+                '  max-spaces-inside: -1\n'
+                '  min-spaces-inside: -1\n'
+                '  max-spaces-inside-empty: -1\n'
+                '  min-spaces-inside-empty: 3\n')
+        self.check('---\n'
+                   'array: {}\n', conf, problem=(2, 9))
+        self.check('---\n'
+                   'array: {   }\n', conf)
+
+    def test_max_spaces_empty(self):
+        conf = ('braces:\n'
+                '  max-spaces-inside: -1\n'
+                '  min-spaces-inside: -1\n'
+                '  max-spaces-inside-empty: 0\n'
+                '  min-spaces-inside-empty: -1\n')
+        self.check('---\n'
+                   'array: {}\n', conf)
+        self.check('---\n'
+                   'array: { }\n', conf, problem=(2, 9))
+
+        conf = ('braces:\n'
+                '  max-spaces-inside: -1\n'
+                '  min-spaces-inside: -1\n'
+                '  max-spaces-inside-empty: 1\n'
+                '  min-spaces-inside-empty: -1\n')
+        self.check('---\n'
+                   'array: {}\n', conf)
+        self.check('---\n'
+                   'array: { }\n', conf)
+        self.check('---\n'
+                   'array: {  }\n', conf, problem=(2, 10))
+
+        conf = ('braces:\n'
+                '  max-spaces-inside: -1\n'
+                '  min-spaces-inside: -1\n'
+                '  max-spaces-inside-empty: 3\n'
+                '  min-spaces-inside-empty: -1\n')
+        self.check('---\n'
+                   'array: {}\n', conf)
+        self.check('---\n'
+                   'array: {   }\n', conf)
+        self.check('---\n'
+                   'array: {    }\n', conf, problem=(2, 12))
+
+    def test_min_and_max_spaces_empty(self):
+        conf = ('braces:\n'
+                '  max-spaces-inside: -1\n'
+                '  min-spaces-inside: -1\n'
+                '  max-spaces-inside-empty: 2\n'
+                '  min-spaces-inside-empty: 1\n')
+        self.check('---\n'
+                   'array: {}\n', conf, problem=(2, 9))
+        self.check('---\n'
+                   'array: { }\n', conf)
+        self.check('---\n'
+                   'array: {  }\n', conf)
+        self.check('---\n'
+                   'array: {   }\n', conf, problem=(2, 11))
+
+    def test_mixed_empty_nonempty(self):
+        conf = ('braces:\n'
+                '  max-spaces-inside: -1\n'
+                '  min-spaces-inside: 1\n'
+                '  max-spaces-inside-empty: 0\n'
+                '  min-spaces-inside-empty: 0\n')
+        self.check('---\n'
+                   'array: { a: 1, b }\n', conf)
+        self.check('---\n'
+                   'array: {a: 1, b}\n', conf,
+                   problem1=(2, 9), problem2=(2, 16))
+        self.check('---\n'
+                   'array: {}\n', conf)
+        self.check('---\n'
+                   'array: { }\n', conf,
+                   problem1=(2, 9))
+
+        conf = ('braces:\n'
+                '  max-spaces-inside: 0\n'
+                '  min-spaces-inside: -1\n'
+                '  max-spaces-inside-empty: 1\n'
+                '  min-spaces-inside-empty: 1\n')
+        self.check('---\n'
+                   'array: { a: 1, b }\n', conf,
+                   problem1=(2, 9), problem2=(2, 17))
+        self.check('---\n'
+                   'array: {a: 1, b}\n', conf)
+        self.check('---\n'
+                   'array: {}\n', conf,
+                   problem1=(2, 9))
+        self.check('---\n'
+                   'array: { }\n', conf)
+
+        conf = ('braces:\n'
+                '  max-spaces-inside: 2\n'
+                '  min-spaces-inside: 1\n'
+                '  max-spaces-inside-empty: 1\n'
+                '  min-spaces-inside-empty: 1\n')
+        self.check('---\n'
+                   'array: { a: 1, b  }\n', conf)
+        self.check('---\n'
+                   'array: {a: 1, b   }\n', conf,
+                   problem1=(2, 9), problem2=(2, 18))
+        self.check('---\n'
+                   'array: {}\n', conf,
+                   problem1=(2, 9))
+        self.check('---\n'
+                   'array: { }\n', conf)
+        self.check('---\n'
+                   'array: {   }\n', conf,
+                   problem1=(2, 11))
+
+        conf = ('braces:\n'
+                '  max-spaces-inside: 1\n'
+                '  min-spaces-inside: 1\n'
+                '  max-spaces-inside-empty: 1\n'
+                '  min-spaces-inside-empty: 1\n')
+        self.check('---\n'
+                   'array: { a: 1, b }\n', conf)
+        self.check('---\n'
+                   'array: {a: 1, b}\n', conf,
+                   problem1=(2, 9), problem2=(2, 16))
+        self.check('---\n'
+                   'array: {}\n', conf,
+                   problem1=(2, 9))
+        self.check('---\n'
+                   'array: { }\n', conf)

--- a/tests/rules/test_brackets.py
+++ b/tests/rules/test_brackets.py
@@ -32,11 +32,19 @@ class ColonTestCase(RuleTestCase):
                    'array7: [   a, b, c ]\n', conf)
 
     def test_min_spaces(self):
-        conf = 'brackets: {max-spaces-inside: -1, min-spaces-inside: 0}'
+        conf = ('brackets:\n'
+                '  max-spaces-inside: -1\n'
+                '  min-spaces-inside: 0\n'
+                '  max-spaces-inside-empty: -1\n'
+                '  min-spaces-inside-empty: -1\n')
         self.check('---\n'
                    'array: []\n', conf)
 
-        conf = 'brackets: {max-spaces-inside: -1, min-spaces-inside: 1}'
+        conf = ('brackets:\n'
+                '  max-spaces-inside: -1\n'
+                '  min-spaces-inside: 1\n'
+                '  max-spaces-inside-empty: -1\n'
+                '  min-spaces-inside-empty: -1\n')
         self.check('---\n'
                    'array: []\n', conf, problem=(2, 9))
         self.check('---\n'
@@ -51,7 +59,11 @@ class ColonTestCase(RuleTestCase):
                    '  b\n'
                    ']\n', conf)
 
-        conf = 'brackets: {max-spaces-inside: -1, min-spaces-inside: 3}'
+        conf = ('brackets:\n'
+                '  max-spaces-inside: -1\n'
+                '  min-spaces-inside: 3\n'
+                '  max-spaces-inside-empty: -1\n'
+                '  min-spaces-inside-empty: -1\n')
         self.check('---\n'
                    'array: [ a, b ]\n', conf,
                    problem1=(2, 10), problem2=(2, 15))
@@ -59,7 +71,11 @@ class ColonTestCase(RuleTestCase):
                    'array: [   a, b   ]\n', conf)
 
     def test_max_spaces(self):
-        conf = 'brackets: {max-spaces-inside: 0, min-spaces-inside: -1}'
+        conf = ('brackets:\n'
+                '  max-spaces-inside: 0\n'
+                '  min-spaces-inside: -1\n'
+                '  max-spaces-inside-empty: -1\n'
+                '  min-spaces-inside-empty: -1\n')
         self.check('---\n'
                    'array: []\n', conf)
         self.check('---\n'
@@ -78,7 +94,11 @@ class ColonTestCase(RuleTestCase):
                    '  b\n'
                    ']\n', conf)
 
-        conf = 'brackets: {max-spaces-inside: 3, min-spaces-inside: -1}'
+        conf = ('brackets:\n'
+                '  max-spaces-inside: 3\n'
+                '  min-spaces-inside: -1\n'
+                '  max-spaces-inside-empty: -1\n'
+                '  min-spaces-inside-empty: -1\n')
         self.check('---\n'
                    'array: [   a, b   ]\n', conf)
         self.check('---\n'
@@ -86,7 +106,11 @@ class ColonTestCase(RuleTestCase):
                    problem1=(2, 12), problem2=(2, 21))
 
     def test_min_and_max_spaces(self):
-        conf = 'brackets: {max-spaces-inside: 0, min-spaces-inside: 0}'
+        conf = ('brackets:\n'
+                '  max-spaces-inside: 0\n'
+                '  min-spaces-inside: 0\n'
+                '  max-spaces-inside-empty: -1\n'
+                '  min-spaces-inside-empty: -1\n')
         self.check('---\n'
                    'array: []\n', conf)
         self.check('---\n'
@@ -94,14 +118,169 @@ class ColonTestCase(RuleTestCase):
         self.check('---\n'
                    'array: [   a, b]\n', conf, problem=(2, 11))
 
-        conf = 'brackets: {max-spaces-inside: 1, min-spaces-inside: 1}'
+        conf = ('brackets:\n'
+                '  max-spaces-inside: 1\n'
+                '  min-spaces-inside: 1\n'
+                '  max-spaces-inside-empty: -1\n'
+                '  min-spaces-inside-empty: -1\n')
         self.check('---\n'
                    'array: [a, b, c ]\n', conf, problem=(2, 9))
 
-        conf = 'brackets: {max-spaces-inside: 2, min-spaces-inside: 0}'
+        conf = ('brackets:\n'
+                '  max-spaces-inside: 2\n'
+                '  min-spaces-inside: 0\n'
+                '  max-spaces-inside-empty: -1\n'
+                '  min-spaces-inside-empty: -1\n')
         self.check('---\n'
                    'array: [a, b, c ]\n', conf)
         self.check('---\n'
                    'array: [  a, b, c ]\n', conf)
         self.check('---\n'
                    'array: [   a, b, c ]\n', conf, problem=(2, 11))
+
+    def test_min_spaces_empty(self):
+        conf = ('brackets:\n'
+                '  max-spaces-inside: -1\n'
+                '  min-spaces-inside: -1\n'
+                '  max-spaces-inside-empty: 0\n'
+                '  min-spaces-inside-empty: 0\n')
+        self.check('---\n'
+                   'array: []\n', conf)
+
+        conf = ('brackets:\n'
+                '  max-spaces-inside: -1\n'
+                '  min-spaces-inside: -1\n'
+                '  max-spaces-inside-empty: -1\n'
+                '  min-spaces-inside-empty: 1\n')
+        self.check('---\n'
+                   'array: []\n', conf, problem=(2, 9))
+        self.check('---\n'
+                   'array: [ ]\n', conf)
+
+        conf = ('brackets:\n'
+                '  max-spaces-inside: -1\n'
+                '  min-spaces-inside: -1\n'
+                '  max-spaces-inside-empty: -1\n'
+                '  min-spaces-inside-empty: 3\n')
+        self.check('---\n'
+                   'array: []\n', conf, problem=(2, 9))
+        self.check('---\n'
+                   'array: [   ]\n', conf)
+
+    def test_max_spaces_empty(self):
+        conf = ('brackets:\n'
+                '  max-spaces-inside: -1\n'
+                '  min-spaces-inside: -1\n'
+                '  max-spaces-inside-empty: 0\n'
+                '  min-spaces-inside-empty: -1\n')
+        self.check('---\n'
+                   'array: []\n', conf)
+        self.check('---\n'
+                   'array: [ ]\n', conf, problem=(2, 9))
+
+        conf = ('brackets:\n'
+                '  max-spaces-inside: -1\n'
+                '  min-spaces-inside: -1\n'
+                '  max-spaces-inside-empty: 1\n'
+                '  min-spaces-inside-empty: -1\n')
+        self.check('---\n'
+                   'array: []\n', conf)
+        self.check('---\n'
+                   'array: [ ]\n', conf)
+        self.check('---\n'
+                   'array: [  ]\n', conf, problem=(2, 10))
+
+        conf = ('brackets:\n'
+                '  max-spaces-inside: -1\n'
+                '  min-spaces-inside: -1\n'
+                '  max-spaces-inside-empty: 3\n'
+                '  min-spaces-inside-empty: -1\n')
+        self.check('---\n'
+                   'array: []\n', conf)
+        self.check('---\n'
+                   'array: [   ]\n', conf)
+        self.check('---\n'
+                   'array: [    ]\n', conf, problem=(2, 12))
+
+    def test_min_and_max_spaces_empty(self):
+        conf = ('brackets:\n'
+                '  max-spaces-inside: -1\n'
+                '  min-spaces-inside: -1\n'
+                '  max-spaces-inside-empty: 2\n'
+                '  min-spaces-inside-empty: 1\n')
+        self.check('---\n'
+                   'array: []\n', conf, problem=(2, 9))
+        self.check('---\n'
+                   'array: [ ]\n', conf)
+        self.check('---\n'
+                   'array: [  ]\n', conf)
+        self.check('---\n'
+                   'array: [   ]\n', conf, problem=(2, 11))
+
+    def test_mixed_empty_nonempty(self):
+        conf = ('brackets:\n'
+                '  max-spaces-inside: -1\n'
+                '  min-spaces-inside: 1\n'
+                '  max-spaces-inside-empty: 0\n'
+                '  min-spaces-inside-empty: 0\n')
+        self.check('---\n'
+                   'array: [ a, b ]\n', conf)
+        self.check('---\n'
+                   'array: [a, b]\n', conf,
+                   problem1=(2, 9), problem2=(2, 13))
+        self.check('---\n'
+                   'array: []\n', conf)
+        self.check('---\n'
+                   'array: [ ]\n', conf,
+                   problem1=(2, 9))
+
+        conf = ('brackets:\n'
+                '  max-spaces-inside: 0\n'
+                '  min-spaces-inside: -1\n'
+                '  max-spaces-inside-empty: 1\n'
+                '  min-spaces-inside-empty: 1\n')
+        self.check('---\n'
+                   'array: [ a, b ]\n', conf,
+                   problem1=(2, 9), problem2=(2, 14))
+        self.check('---\n'
+                   'array: [a, b]\n', conf)
+        self.check('---\n'
+                   'array: []\n', conf,
+                   problem1=(2, 9))
+        self.check('---\n'
+                   'array: [ ]\n', conf)
+
+        conf = ('brackets:\n'
+                '  max-spaces-inside: 2\n'
+                '  min-spaces-inside: 1\n'
+                '  max-spaces-inside-empty: 1\n'
+                '  min-spaces-inside-empty: 1\n')
+        self.check('---\n'
+                   'array: [ a, b  ]\n', conf)
+        self.check('---\n'
+                   'array: [a, b   ]\n', conf,
+                   problem1=(2, 9), problem2=(2, 15))
+        self.check('---\n'
+                   'array: []\n', conf,
+                   problem1=(2, 9))
+        self.check('---\n'
+                   'array: [ ]\n', conf)
+        self.check('---\n'
+                   'array: [   ]\n', conf,
+                   problem1=(2, 11))
+
+        conf = ('brackets:\n'
+                '  max-spaces-inside: 1\n'
+                '  min-spaces-inside: 1\n'
+                '  max-spaces-inside-empty: 1\n'
+                '  min-spaces-inside-empty: 1\n')
+        self.check('---\n'
+                   'array: [ a, b ]\n', conf)
+        self.check('---\n'
+                   'array: [a, b]\n', conf,
+                   problem1=(2, 9), problem2=(2, 13))
+        self.check('---\n'
+                   'array: []\n', conf,
+                   problem1=(2, 9))
+        self.check('---\n'
+                   'array: [ ]\n', conf)

--- a/yamllint/conf/default.yaml
+++ b/yamllint/conf/default.yaml
@@ -4,9 +4,13 @@ rules:
   braces:
     min-spaces-inside: 0
     max-spaces-inside: 0
+    min-spaces-inside-empty: -1
+    max-spaces-inside-empty: -1
   brackets:
     min-spaces-inside: 0
     max-spaces-inside: 0
+    min-spaces-inside-empty: -1
+    max-spaces-inside-empty: -1
   colons:
     max-spaces-before: 0
     max-spaces-after: 1


### PR DESCRIPTION
This allows empty objects (e.g. `[]`, `{}`) to be handled separately from non-empty ones. In my case, I want `min-spaces-inside: 1` and `max-spaces-inside: 1` for braces and brackets, but I want empty items to have no spaces (`min-spaces-inside-empty: 0` and `max-spaces-inside-empty: 0`).

This has been done as backward-compatible as possible, defaulting the new settings to `-1` and using the non-empty configuration variable value in the the case of `-1`. Thus, users should see no difference in behavior of existing configurations unless one of the new variables is set.