### PR TITLE
Add information about Emacs integration

### DIFF
--- a/docs/text_editors.rst
+++ b/docs/text_editors.rst
@@ -27,6 +27,12 @@ Assuming that the `neomake <https://github.com/benekastah/neomake>`_ plugin is
 installed, yamllint is supported by default. It is automatically enabled when
 editing YAML files.
 
+Emacs
+-----
+
+If you are `flycheck <https://github.com/flycheck/flycheck>`_ user, you can use
+`flycheck-yamllint <https://github.com/krzysztof-magosa/flycheck-yamllint>`_ integration.
+
 Other text editors
 ------------------
 


### PR DESCRIPTION
Hi.

I've recently created Flycheck plugin which integrates YAMLint into Emacs. I'm waiting for MELPA acceptance, but in meantime it can be easily installed directly from my GitHub repository. This pull request adds information about that plugin to editors section of documentation.

Cheers.
