### PR TITLE
Change format of ignore patterns

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -125,20 +125,20 @@ Specific files can be ignored (totally or for some rules only) using a
 .. code:: yaml
 
  # For all rules
- ignore: |
-   *.dont-lint-me.yaml
-   /bin/
-   !/bin/*.lint-me-anyway.yaml
+ ignore:
+   - "*.dont-lint-me.yaml"
+   - /bin/
+   - "!/bin/*.lint-me-anyway.yaml"
 
  rules:
    key-duplicates:
-     ignore: |
-       generated
-       *.template.yaml
+     ignore:
+       - generated
+       - "*.template.yaml"
    trailing-spaces:
-     ignore: |
-       *.ignore-trailing-spaces.yaml
-       /ascii-art/*
+     ignore:
+       - "*.ignore-trailing-spaces.yaml"
+       - "/ascii-art/*"
 
 `Read more in the complete documentation! <https://yamllint.readthedocs.io/>`_
 

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -127,10 +127,10 @@ You can either totally ignore files (they won't be looked at):
 
  extends: default
 
- ignore: |
-   /this/specific/file.yaml
-   /all/this/directory/
-   *.template.yaml
+ ignore:
+   - /this/specific/file.yaml
+   - /all/this/directory/
+   - "*.template.yaml"
 
 or ignore paths only for specific rules:
 
@@ -140,9 +140,9 @@ or ignore paths only for specific rules:
 
  rules:
    trailing-spaces:
-     ignore: |
-       /this-file-has-trailing-spaces-but-it-is-OK.yaml
-       /generated/*.yaml
+     ignore:
+       - /this-file-has-trailing-spaces-but-it-is-OK.yaml
+       - "/generated/*.yaml"
 
 Note that this ``.gitignore``-style path pattern allows complex path
 exclusion/inclusion, see the `pathspec README file
@@ -152,19 +152,19 @@ Here is a more complex example:
 .. code-block:: yaml
 
  # For all rules
- ignore: |
-   *.dont-lint-me.yaml
-   /bin/
-   !/bin/*.lint-me-anyway.yaml
+ ignore:
+   - "*.dont-lint-me.yaml"
+   - /bin/
+   - "!/bin/*.lint-me-anyway.yaml"
 
  extends: default
 
  rules:
    key-duplicates:
-     ignore: |
-       generated
-       *.template.yaml
+     ignore:
+       - generated
+       - "*.template.yaml"
    trailing-spaces:
-     ignore: |
-       *.ignore-trailing-spaces.yaml
-       /ascii-art/*
+     ignore:
+       - "*.ignore-trailing-spaces.yaml"
+       - "/ascii-art/*"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -310,21 +310,21 @@ class IgnorePathConfigTestCase(unittest.TestCase):
             's/s/ign-trail/s/s/file.yaml': bad_yaml,
             's/s/ign-trail/s/s/file2.lint-me-anyway.yaml': bad_yaml,
 
-            '.yamllint': 'ignore: |\n'
-                         '  *.dont-lint-me.yaml\n'
-                         '  /bin/\n'
-                         '  !/bin/*.lint-me-anyway.yaml\n'
+            '.yamllint': 'ignore:\n'
+                         '  - "*.dont-lint-me.yaml"\n'
+                         '  - /bin/\n'
+                         '  - "!/bin/*.lint-me-anyway.yaml"\n'
                          '\n'
                          'extends: default\n'
                          '\n'
                          'rules:\n'
                          '  key-duplicates:\n'
-                         '    ignore: |\n'
-                         '      /ign-dup\n'
+                         '    ignore:\n'
+                         '      - /ign-dup\n'
                          '  trailing-spaces:\n'
-                         '    ignore: |\n'
-                         '      ign-trail\n'
-                         '      !*.lint-me-anyway.yaml\n',
+                         '    ignore:\n'
+                         '      - ign-trail\n'
+                         '      - "!*.lint-me-anyway.yaml"\n',
         })
 
         cls.backup_wd = os.getcwd()

--- a/yamllint/config.py
+++ b/yamllint/config.py
@@ -85,11 +85,11 @@ class YamlLintConfig(object):
                 raise YamlLintConfigError('invalid config: %s' % e)
 
         if 'ignore' in conf:
-            if type(conf['ignore']) != str:
+            if type(conf['ignore']) != list or not all((isinstance(p, str) for p in conf['ignore'])):
                 raise YamlLintConfigError(
                     'invalid config: ignore should be a list of patterns')
             self.ignore = pathspec.PathSpec.from_lines(
-                'gitwildmatch', conf['ignore'].splitlines())
+                'gitwildmatch', conf['ignore'])
 
     def validate(self):
         for id in self.rules:
@@ -110,11 +110,11 @@ def validate_rule_conf(rule, conf):
     if type(conf) == dict:
         if ('ignore' in conf and
                 type(conf['ignore']) != pathspec.pathspec.PathSpec):
-            if type(conf['ignore']) != str:
+            if type(conf['ignore']) != list or not all((isinstance(p, str) for p in conf['ignore'])):
                 raise YamlLintConfigError(
                     'invalid config: ignore should be a list of patterns')
             conf['ignore'] = pathspec.PathSpec.from_lines(
-                'gitwildmatch', conf['ignore'].splitlines())
+                'gitwildmatch', conf['ignore'])
 
         if 'level' not in conf:
             conf['level'] = 'error'


### PR DESCRIPTION
Use yaml lists:

```yaml
ignore:
  - generated
  - "*.template.yaml"
```

instead of multiline strings:

```yaml
ignore: |
  generated
  *.template.yaml
```

This also fixes the wrong error messages when using the new config
format with ymallit v1.8.0/v1.8.1.

The only problem I see is that this will break config files with the
latter ignore pattern format. But AFAIK there is no major distribution packaging >= v1.8.0:

- https://apps.fedoraproject.org/packages/yamllint
- https://packages.debian.org/sid/yamllint
- https://packages.ubuntu.com/yakkety/yamllint