### PR TITLE
fix yamllint error

### DIFF
--- a/docs/integration.rst
+++ b/docs/integration.rst
@@ -9,6 +9,7 @@ Here is an example, to add in your .pre-commit-config.yaml
 
 .. code:: yaml
 
+  ---
   # Update the sha variable with the release version that you want, from the yamllint repo
   - repo: https://github.com/adrienverge/yamllint.git
     sha: v1.8.1


### PR DESCRIPTION
Hi, after using yamllint with pre-commit I noticed the following:

```yaml
.pre-commit-config.yaml
  2:1       warning  missing document start "---"  (document-start)
```

Maybe you can consider merging this :smile: 

cheers