### PR TITLE
Fix indentation rule for key following empty list

### DIFF
--- a/tests/rules/test_indentation.py
+++ b/tests/rules/test_indentation.py
@@ -1211,6 +1211,20 @@ class IndentationTestCase(RuleTestCase):
                    '        - name: Linux\n'
                    '         date: 1991\n'
                    '...\n', conf, problem=(5, 10, 'syntax'))
+        conf = 'indentation: {spaces: 2, indent-sequences: true}'
+        self.check('---\n'
+                   'a:\n'
+                   '-\n'  # empty list
+                   'b: c\n'
+                   '...\n', conf, problem=(3, 1))
+        conf = 'indentation: {spaces: 2, indent-sequences: consistent}'
+        self.check('---\n'
+                   'a:\n'
+                   '  -\n'  # empty list
+                   'b:\n'
+                   '-\n'
+                   'c: d\n'
+                   '...\n', conf, problem=(5, 1))
 
     def test_over_indented(self):
         conf = 'indentation: {spaces: 2, indent-sequences: consistent}'
@@ -1267,6 +1281,20 @@ class IndentationTestCase(RuleTestCase):
                    '    - subel\n'
                    '...\n', conf,
                    problem=(2, 3))
+        conf = 'indentation: {spaces: 2, indent-sequences: false}'
+        self.check('---\n'
+                   'a:\n'
+                   '  -\n'  # empty list
+                   'b: c\n'
+                   '...\n', conf, problem=(3, 3))
+        conf = 'indentation: {spaces: 2, indent-sequences: consistent}'
+        self.check('---\n'
+                   'a:\n'
+                   '-\n'  # empty list
+                   'b:\n'
+                   '  -\n'
+                   'c: d\n'
+                   '...\n', conf, problem=(5, 3))
 
     def test_multi_lines(self):
         conf = 'indentation: {spaces: consistent, indent-sequences: true}'

--- a/tests/rules/test_indentation.py
+++ b/tests/rules/test_indentation.py
@@ -589,6 +589,9 @@ class IndentationTestCase(RuleTestCase):
                    '    date: 1969\n'
                    '  - name: Linux\n'
                    '    date: 1991\n'
+                   '  k4:\n'
+                   '  -\n'
+                   '  k5: v3\n'
                    '...\n', conf)
         conf = 'indentation: {spaces: 2, indent-sequences: true}'
         self.check('---\n'

--- a/yamllint/rules/indentation.py
+++ b/yamllint/rules/indentation.py
@@ -399,6 +399,10 @@ def _check(conf, token, prev, next, nextnext, context):
             #   - item 1
             #   - item 2
             indent = next.start_mark.column
+        elif next.start_mark.column == token.start_mark.column:
+            #   -
+            #   key: value
+            indent = next.start_mark.column
         else:
             #   -
             #     item 1


### PR DESCRIPTION
If a key-value pair follows an empty list, i.e.:

```yaml
a:
-
b: c
```

yamllint will complain:

```
warning  wrong indentation: expected 2 but found 0  (indentation)
```

This is because it is expecting the second key to be a continuation of
the block entry above:

```yaml
a:
-
  b: c
```

However, both are perfectly valid, though structurally different.