### PR TITLE
88 anchor references seen as duplicate key

### DIFF
--- a/tests/rules/test_key_duplicates.py
+++ b/tests/rules/test_key_duplicates.py
@@ -78,6 +78,15 @@ class KeyDuplicatesTestCase(RuleTestCase):
                    '    duplicates with\n'
                    '    many styles\n'
                    ': 1\n', conf)
+        self.check('---\n'
+                   'Merge Keys are OK:\n'
+                   'anchor_one: &anchor_one\n'
+                   '  one: one\n'
+                   'anchor_two: &anchor_two\n'
+                   '  two: two\n'
+                   'anchor_reference:\n'
+                   '  <<: *anchor_one\n'
+                   '  <<: *anchor_two\n', conf)
 
     def test_enabled(self):
         conf = 'key-duplicates: enable'
@@ -147,6 +156,15 @@ class KeyDuplicatesTestCase(RuleTestCase):
                    ': 1\n', conf,
                    problem1=(3, 1), problem2=(4, 1), problem3=(5, 3),
                    problem4=(7, 3))
+        self.check('---\n'
+                   'Merge Keys are OK:\n'
+                   'anchor_one: &anchor_one\n'
+                   '  one: one\n'
+                   'anchor_two: &anchor_two\n'
+                   '  two: two\n'
+                   'anchor_reference:\n'
+                   '  <<: *anchor_one\n'
+                   '  <<: *anchor_two\n', conf)
 
     def test_key_tokens_in_flow_sequences(self):
         conf = 'key-duplicates: enable'

--- a/yamllint/rules/key_duplicates.py
+++ b/yamllint/rules/key_duplicates.py
@@ -91,7 +91,9 @@ def check(conf, token, prev, next, nextnext, context):
         # This check is done because KeyTokens can be found inside flow
         # sequences... strange, but allowed.
         if len(context['stack']) > 0 and context['stack'][-1].type == MAP:
-            if next.value in context['stack'][-1].keys:
+            if (next.value in context['stack'][-1].keys and
+                    # `<<` is "merge key", see http://yaml.org/type/merge.html
+                    next.value != '<<'):
                 yield LintProblem(
                     next.start_mark.line + 1, next.start_mark.column + 1,
                     'duplication of key "%s" in mapping' % next.value)


### PR DESCRIPTION
fixes #88 

LMK if you spot anything fishy. I couldn't dedicate much time to tracing back so my method may be wrong --- but all unit tests pass so if there is something wrong, it's not covered.