### PR TITLE
CI: Fix failing tests for Python 3.6 because of flake8-import-order

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,9 @@ install:
   - pip install .
 script:
   - if [[ $TRAVIS_PYTHON_VERSION != 2.6 ]]; then flake8 .; fi
+  # Because of https://github.com/PyCQA/flake8-import-order/issues/149
+  # otherwise tests fail with Python 3.6:
+  - pip uninstall --yes enum34
   - yamllint --strict $(git ls-files '*.yaml' '*.yml')
   - coverage run --source=yamllint setup.py test
   - if [[ $TRAVIS_PYTHON_VERSION != 2* ]]; then


### PR DESCRIPTION
See issue https://github.com/PyCQA/flake8-import-order/issues/149