### PR TITLE
Fix CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,9 @@ python:
   - 3.6
   - nightly
 install:
-  - pip install pyyaml flake8 flake8-import-order coveralls sphinx
+  - pip install pyyaml flake8 flake8-import-order coveralls
   - if [[ $TRAVIS_PYTHON_VERSION == 2.6 ]]; then pip install unittest2; fi
+  - if [[ $TRAVIS_PYTHON_VERSION != 2* ]]; then pip install sphinx; fi
   - pip install .
 script:
   - if [[ $TRAVIS_PYTHON_VERSION != 2.6 ]]; then flake8 .; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,9 +14,6 @@ install:
   - pip install .
 script:
   - if [[ $TRAVIS_PYTHON_VERSION != 2.6 ]]; then flake8 .; fi
-  # Because of https://github.com/PyCQA/flake8-import-order/issues/149
-  # otherwise tests fail with Python 3.6:
-  - pip uninstall --yes enum34
   - yamllint --strict $(git ls-files '*.yaml' '*.yml')
   - coverage run --source=yamllint setup.py test
   - if [[ $TRAVIS_PYTHON_VERSION != 2* ]]; then


### PR DESCRIPTION
### CI: Remove Travis hack for enum34 crashing on Python 3.6

Revert commit 8b9eab3, it is not needed anymore.

---

### CI: Don't install Sphinx if Python 2

Recently builds started to fail with:

    Collecting sphinx
      Downloading Sphinx-1.7.2-py2.py3-none-any.whl (1.9MB)
        100% |████████████████████████████████| 1.9MB 731kB/s
    Sphinx requires Python '>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*'
    but the running Python is 2.6.9
