### PR TITLE
parser: Fix crash with latest PyYAML

### DIFF
--- a/yamllint/parser.py
+++ b/yamllint/parser.py
@@ -125,7 +125,8 @@ def token_or_comment_generator(buffer):
         curr = yaml_loader.get_token()
         while curr is not None:
             next = yaml_loader.get_token()
-            nextnext = yaml_loader.peek_token()
+            nextnext = (yaml_loader.peek_token()
+                        if yaml_loader.check_token() else None)
 
             yield Token(curr.start_mark.line + 1, curr, prev, next, nextnext)
 


### PR DESCRIPTION
There is a backwards-incompatible change in PyYAML that induces a crash
if `check_token()` is not called before `peek_token()`. See commit
a02d17a in PyYAML or https://github.com/yaml/pyyaml/pull/150.

Closes #105.