### PR TITLE
Added configuration for the syntax checker

### DIFF
--- a/yamllint/config.py
+++ b/yamllint/config.py
@@ -31,7 +31,7 @@ class YamlLintConfig(object):
         assert (content is None) ^ (file is None)
 
         self.ignore = None
-        self.syntax_checker = None
+        self.syntax_checker = {'enabled': True, 'level': 'error'}
 
         if file is not None:
             with open(file) as f:
@@ -109,8 +109,6 @@ class YamlLintConfig(object):
                 raise YamlLintConfigError('invalid config: syntax-checker.level should be "error" or "warning"')
 
             self.syntax_checker = syntax_checker
-        else:
-            self.syntax_checker = {'enabled': True, 'level': 'error'}
 
     def validate(self):
         for id in self.rules:

--- a/yamllint/config.py
+++ b/yamllint/config.py
@@ -31,6 +31,7 @@ class YamlLintConfig(object):
         assert (content is None) ^ (file is None)
 
         self.ignore = None
+        self.syntax_checker = None
 
         if file is not None:
             with open(file) as f:
@@ -90,6 +91,26 @@ class YamlLintConfig(object):
                     'invalid config: ignore should contain file patterns')
             self.ignore = pathspec.PathSpec.from_lines(
                 'gitwildmatch', conf['ignore'].splitlines())
+
+        if 'syntax-checker' in conf:
+            if type(conf['syntax-checker']) != dict:
+                raise YamlLintConfigError('invalid config: syntax-checker should be dict')
+
+            syntax_checker = conf['syntax-checker']
+
+            if 'enabled' not in syntax_checker:
+                syntax_checker['enabled'] = True
+            elif type(syntax_checker['enabled']) != bool:
+                raise YamlLintConfigError('invalid config: syntax-checker.enabled should should be true or false')
+
+            if 'level' not in syntax_checker:
+                syntax_checker['level'] = 'error'
+            elif syntax_checker['level'] not in ['error', 'warning']:
+                raise YamlLintConfigError('invalid config: syntax-checker.level should be "error" or "warning"')
+
+            self.syntax_checker = syntax_checker
+        else:
+            self.syntax_checker = {'enabled': True, 'level': 'error'}
 
     def validate(self):
         for id in self.rules:

--- a/yamllint/linter.py
+++ b/yamllint/linter.py
@@ -174,15 +174,16 @@ def get_cosmetic_problems(buffer, conf, filepath):
             cache = []
 
 
-def get_syntax_error(buffer):
+def get_syntax_error(buffer, conf):
     try:
         list(yaml.parse(buffer, Loader=yaml.BaseLoader))
     except yaml.error.MarkedYAMLError as e:
-        problem = LintProblem(e.problem_mark.line + 1,
-                              e.problem_mark.column + 1,
-                              'syntax error: ' + e.problem)
-        problem.level = 'error'
-        return problem
+        if conf.syntax_checker['enabled']:
+            problem = LintProblem(e.problem_mark.line + 1,
+                                  e.problem_mark.column + 1,
+                                  'syntax error: ' + e.problem)
+            problem.level = conf.syntax_checker['level']
+            return problem
 
 
 def _run(buffer, conf, filepath):
@@ -191,7 +192,7 @@ def _run(buffer, conf, filepath):
 
     # If the document contains a syntax error, save it and yield it at the
     # right line
-    syntax_error = get_syntax_error(buffer)
+    syntax_error = get_syntax_error(buffer, conf)
 
     for problem in get_cosmetic_problems(buffer, conf, filepath):
         # Insert the syntax error (if any) at the right place...


### PR DESCRIPTION
Hello,

I've tried to use yamlliner for my needs, but I can't.
Yaml files in my projects are contain some placeholders, as the result yamlliner was crashed with syntax error.

I decided to configure syntax checker level or disable it at all, but didn't find any configuration options for that.

So I've made changes and want to contribute it to official yamlliner.

I've added optional `syntax-checker` configuration with optional sub-options: `enabled` and `level`, example for this configuration:
```yaml
syntax-checker:
    enabled: false
    level: warning
rules:
    ...
```
Default configuration options (if you don't send some of there or all options) are:
```yaml
syntax-checker:
    enabled: true
    level: error
rules:
    ...
```