### PR TITLE
EPEL on CentOS

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -38,7 +38,8 @@ Screenshot
 Installation
 ^^^^^^^^^^^^
 
-On Fedora / CentOS:
+On Fedora / CentOS (note: `EPEL <https://fedoraproject.org/wiki/EPEL>`_ is
+required on CentOS):
 
 .. code:: bash
 


### PR DESCRIPTION
I noticed that yamllint isn't in the base repo for CentOS 7, so I added a note about requiring EPEL.