### PR TITLE
cli: read optional config from YAMLLINT_CONFIG

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -165,7 +165,19 @@ class CommandLineTestCase(unittest.TestCase):
 
         out, err = sys.stdout.getvalue(), sys.stderr.getvalue()
         self.assertEqual(out, '')
-        self.assertRegexpMatches(err, r'^invalid config: not a dict')
+        self.assertRegexpMatches(err, r'No such file or directory')
+
+    def test_run_with_environment_variable(self):
+        sys.stdout, sys.stderr = StringIO(), StringIO()
+        rules = '{extends: default, rules: {document-start: {present: false}}}'
+        with self.assertRaises(SystemExit) as ctx:
+            os.environ['YAMLLINT_CONFIG'] = rules
+            cli.run((os.path.join(self.wd, 'warn.yaml'), ))
+
+        self.assertEqual(ctx.exception.code, 0)
+        out = sys.stdout.getvalue()
+        self.assertEqual(out, '')
+        del os.environ['YAMLLINT_CONFIG']
 
     def test_run_with_config_file(self):
         with open(os.path.join(self.wd, 'config'), 'w') as f:

--- a/yamllint/cli.py
+++ b/yamllint/cli.py
@@ -94,6 +94,7 @@ def run(argv=None):
                               help='path to a custom configuration')
     config_group.add_argument('-d', '--config-data', dest='config_data',
                               action='store',
+                              default=os.environ.get('YAMLLINT_CONFIG', ''),
                               help='custom configuration (as YAML source)')
     parser.add_argument('-f', '--format',
                         choices=('parsable', 'standard'), default='standard',
@@ -117,8 +118,8 @@ def run(argv=None):
         user_global_config = os.path.expanduser('~/.config/yamllint/config')
 
     try:
-        if args.config_data is not None:
-            if args.config_data != '' and ':' not in args.config_data:
+        if args.config_data != '':
+            if ':' not in args.config_data:
                 args.config_data = 'extends: ' + args.config_data
             conf = YamlLintConfig(content=args.config_data)
         elif args.config_file is not None:


### PR DESCRIPTION
This is a "minor" abi break (?) since empty configs are disregarded instead of failing.

Fixes: https://github.com/adrienverge/yamllint/issues/107