### PR TITLE
CI: Fix tests failing on Travis for Python 2.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,14 +9,19 @@ python:
   - 3.6
   - nightly
 install:
-  - pip install pyyaml flake8 flake8-import-order coveralls
+  - pip install pyyaml flake8 flake8-import-order
   - if [[ $TRAVIS_PYTHON_VERSION == 2.6 ]]; then pip install unittest2; fi
+  - if [[ $TRAVIS_PYTHON_VERSION != 2.6 ]]; then pip install coveralls; fi
   - if [[ $TRAVIS_PYTHON_VERSION != 2* ]]; then pip install sphinx; fi
   - pip install .
 script:
   - if [[ $TRAVIS_PYTHON_VERSION != 2.6 ]]; then flake8 .; fi
   - yamllint --strict $(git ls-files '*.yaml' '*.yml')
-  - coverage run --source=yamllint setup.py test
+  - if [[ $TRAVIS_PYTHON_VERSION != 2.6 ]]; then
+      coverage run --source=yamllint setup.py test;
+    else
+      python setup.py test;
+    fi
   - if [[ $TRAVIS_PYTHON_VERSION != 2* ]]; then
       python setup.py build_sphinx;
     fi


### PR DESCRIPTION
Because installing dependencies for `coveralls` now fails with:

    Collecting pycparser (from cffi>=1.7->cryptography>=1.3.4; python_version <= "2.7" and extra == "secure"->urllib3[secure]; python_version < "3"->coveralls)
    [...]
    pycparser requires Python '>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*' but the running Python is 2.6.9