### PR TITLE
quoted-strings: Fix broken rule

### DIFF
--- a/tests/rules/test_quoted_strings.py
+++ b/tests/rules/test_quoted_strings.py
@@ -34,19 +34,19 @@ class QuotedTestCase(RuleTestCase):
     def test_quote_type_any(self):
         conf = 'quoted-strings: {quote-type: any}\n'
         self.check('---\n'
-                   'string1: "foo"\n'
-                   'number1: 123\n'                          # fails
-                   'string2: foo\n'                          # fails
+                   'boolean1: true\n'
+                   'number1: 123\n'
+                   'string1: foo\n'                          # fails
+                   'string2: "foo"\n'
                    'string3: \'bar\'\n'
-                   'string4: !!str genericstring\n'          # fails
-                   'string5: !!str 456\n'                    # fails
+                   'string4: !!str genericstring\n'
+                   'string5: !!str 456\n'
                    'string6: !!str "quotedgenericstring"\n'
                    'binary: !!binary binstring\n'
                    'integer: !!int intstring\n'
-                   'boolean1: !!bool boolstring\n'
-                   'boolean2: !!bool "quotedboolstring"\n',
-                   conf, problem1=(3, 10), problem2=(4, 10),
-                   problem3=(6, 16), problem4=(7, 16))
+                   'boolean2: !!bool boolstring\n'
+                   'boolean3: !!bool "quotedboolstring"\n',
+                   conf, problem=(4, 10))
         self.check('---\n'
                    'multiline string 1: |\n'
                    '  line 1\n'
@@ -65,19 +65,19 @@ class QuotedTestCase(RuleTestCase):
     def test_quote_type_single(self):
         conf = 'quoted-strings: {quote-type: single}\n'
         self.check('---\n'
-                   'string1: "foo"\n'                        # fails
-                   'number1: 123\n'                          # fails
-                   'string2: foo\n'                          # fails
+                   'boolean1: true\n'
+                   'number1: 123\n'
+                   'string1: foo\n'                          # fails
+                   'string2: "foo"\n'                        # fails
                    'string3: \'bar\'\n'
-                   'string4: !!str genericstring\n'          # fails
-                   'string5: !!str 456\n'                    # fails
-                   'string6: !!str "quotedgenericstring"\n'  # fails
+                   'string4: !!str genericstring\n'
+                   'string5: !!str 456\n'
+                   'string6: !!str "quotedgenericstring"\n'
                    'binary: !!binary binstring\n'
                    'integer: !!int intstring\n'
-                   'boolean1: !!bool boolstring\n'
-                   'boolean2: !!bool "quotedboolstring"\n',
-                   conf, problem1=(2, 10), problem2=(3, 10), problem3=(4, 10),
-                   problem4=(6, 16), problem5=(7, 16), problem6=(8, 16))
+                   'boolean2: !!bool boolstring\n'
+                   'boolean3: !!bool "quotedboolstring"\n',
+                   conf, problem1=(4, 10), problem2=(5, 10))
         self.check('---\n'
                    'multiline string 1: |\n'
                    '  line 1\n'
@@ -96,19 +96,19 @@ class QuotedTestCase(RuleTestCase):
     def test_quote_type_double(self):
         conf = 'quoted-strings: {quote-type: double}\n'
         self.check('---\n'
-                   'string1: "foo"\n'
-                   'number1: 123\n'                          # fails
-                   'string2: foo\n'                          # fails
+                   'boolean1: true\n'
+                   'number1: 123\n'
+                   'string1: foo\n'                          # fails
+                   'string2: "foo"\n'
                    'string3: \'bar\'\n'                      # fails
-                   'string4: !!str genericstring\n'          # fails
-                   'string5: !!str 456\n'                    # fails
+                   'string4: !!str genericstring\n'
+                   'string5: !!str 456\n'
                    'string6: !!str "quotedgenericstring"\n'
                    'binary: !!binary binstring\n'
                    'integer: !!int intstring\n'
-                   'boolean1: !!bool boolstring\n'
-                   'boolean2: !!bool "quotedboolstring"\n',
-                   conf, problem1=(3, 10), problem2=(4, 10), problem3=(5, 10),
-                   problem4=(6, 16), problem5=(7, 16))
+                   'boolean2: !!bool boolstring\n'
+                   'boolean3: !!bool "quotedboolstring"\n',
+                   conf, problem1=(4, 10), problem2=(6, 10))
         self.check('---\n'
                    'multiline string 1: |\n'
                    '  line 1\n'


### PR DESCRIPTION
Original implementation was completely broken. Documentation and actual
behavior were different. Numbers and booleans were detected as wrong, as
well as explicit types.

Fixes #136 and #130.