### PR TITLE
Travis CI: Add Python 3.7, 3.8a, Drop Python 3.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ install:
   - if [[ $TRAVIS_PYTHON_VERSION != 2* ]]; then pip install sphinx; fi
   - pip install .
 script:
-  - flake8 .
+  - if [[ $TRAVIS_PYTHON_VERSION != nightly ]]; then flake8 .; fi
   - if [[ $TRAVIS_PYTHON_VERSION != 2* ]]; then doc8 $(git ls-files '*.rst'); fi
   - yamllint --strict $(git ls-files '*.yaml' '*.yml')
   - coverage run --source=yamllint setup.py test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,19 @@
 ---
+dist: xenial  # required for Python >= 3.7 (travis-ci/travis-ci#9069)
 language: python
 python:
   - 2.7
   - 3.4
   - 3.5
   - 3.6
+  - 3.7
   - nightly
 install:
   - pip install pyyaml coveralls flake8 flake8-import-order
   - if [[ $TRAVIS_PYTHON_VERSION != 2* ]]; then pip install sphinx; fi
   - pip install .
 script:
-  - flake8 .
+  - if [[ $TRAVIS_PYTHON_VERSION != nightly ]]; then flake8 .; fi
   - yamllint --strict $(git ls-files '*.yaml' '*.yml')
   - coverage run --source=yamllint setup.py test
   - if [[ $TRAVIS_PYTHON_VERSION != 2* ]]; then


### PR DESCRIPTION
* Adds Python 3.7.1 and a current nightly build of Python 3.8 alpha.
* Python 3.3 reached its end of life in 2017 https://devguide.python.org/#branchstatus