### PR TITLE
CI: Drop Python 3.3 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: python
 python:
   - 2.6
   - 2.7
-  - 3.3
   - 3.4
   - 3.5
   - 3.6


### PR DESCRIPTION
The `pkg_resources` package inside `setuptools` explicitly [disallows
Python 3.3](https://github.com/pypa/setuptools/commit/7392f01ffced3acfdef25b0b2d55cefdc6ee468a#diff-81de4a30a55fcc3fb944f8387ea9ec94):

    if (3, 0) < sys.version_info < (3, 4):
        raise RuntimeError("Python 3.4 or later is required")

It's time to drop support for 3.3.