### PR TITLE
line-length, unicode and Python 2

### DIFF
--- a/tests/rules/test_line_length.py
+++ b/tests/rules/test_line_length.py
@@ -14,6 +14,13 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import sys
+try:
+    assert sys.version_info >= (2, 7)
+    import unittest
+except AssertionError:
+    import unittest2 as unittest
+
 from tests.common import RuleTestCase
 
 
@@ -155,3 +162,16 @@ class LineLengthTestCase(RuleTestCase):
                    'content: |\n'
                    '  {% this line is' + 99 * ' really' + ' long %}\n',
                    conf, problem=(3, 81))
+
+    @unittest.skipIf(sys.version_info < (3, 0), 'Python 2 not supported')
+    def test_unicode(self):
+        conf = 'line-length: {max: 53}'
+        self.check('---\n'
+                   '# This is a test to check if “line-length” works nice\n'
+                   'with: “unicode characters” that span accross bytes! ↺\n',
+                   conf)
+        conf = 'line-length: {max: 52}'
+        self.check('---\n'
+                   '# This is a test to check if “line-length” works nice\n'
+                   'with: “unicode characters” that span accross bytes! ↺\n',
+                   conf, problem1=(2, 53), problem2=(3, 53))

--- a/yamllint/rules/line_length.py
+++ b/yamllint/rules/line_length.py
@@ -17,6 +17,10 @@
 """
 Use this rule to set a limit to lines length.
 
+Note: with Python 2, the ``line-length`` rule may not work properly with
+unicode characters because of the way strings are represented in bytes. We
+recommend running yamllint with Python 3.
+
 .. rubric:: Options
 
 * ``max`` defines the maximal (inclusive) length of lines.


### PR DESCRIPTION
### line-length: Add tests for lines containing unicode characters

Some unicode characters span accross multiple bytes. Python 3 is OK with
that, but Python 2 reports an incorrect number of characters.

Related to https://github.com/adrienverge/yamllint/issues/146

---

### docs: Warn about Python 2 and problems with line-length

Closes #146.
