### PR TITLE
Support ignoring shebangs

### DIFF
--- a/tests/rules/test_comments.py
+++ b/tests/rules/test_comments.py
@@ -80,6 +80,33 @@ class CommentsTestCase(RuleTestCase):
                    problem3=(9, 2), problem4=(10, 4),
                    problem5=(15, 3))
 
+    def test_shebang(self):
+        conf = ('comments:\n'
+                '  require-starting-space: true\n'
+                '  ignore-shebangs: false\n'
+                'comments-indentation: disable\n')
+        self.check('#!/bin/env my-interpreter\n',
+                   conf, problem1=(1, 2))
+        self.check('#!/bin/env my-interpreter\n'
+                   '---\n'
+                   '#comment\n'
+                   '#!/bin/env my-interpreter\n'
+                   '', conf,
+                   problem1=(1, 2), problem2=(3, 2), problem3=(4, 2))
+
+    def test_ignore_shebang(self):
+        conf = ('comments:\n'
+                '  require-starting-space: true\n'
+                '  ignore-shebangs: true\n'
+                'comments-indentation: disable\n')
+        self.check('#!/bin/env my-interpreter\n', conf)
+        self.check('#!/bin/env my-interpreter\n'
+                   '---\n'
+                   '#comment\n'
+                   '#!/bin/env my-interpreter\n'
+                   '', conf,
+                   problem2=(3, 2), problem3=(4, 2))
+
     def test_spaces_from_content(self):
         conf = ('comments:\n'
                 '  require-starting-space: false\n'

--- a/tests/rules/test_comments.py
+++ b/tests/rules/test_comments.py
@@ -84,28 +84,43 @@ class CommentsTestCase(RuleTestCase):
         conf = ('comments:\n'
                 '  require-starting-space: true\n'
                 '  ignore-shebangs: false\n'
-                'comments-indentation: disable\n')
+                'comments-indentation: disable\n'
+                'document-start: disable\n')
         self.check('#!/bin/env my-interpreter\n',
                    conf, problem1=(1, 2))
+        self.check('# comment\n'
+                   '#!/bin/env my-interpreter\n', conf,
+                   problem1=(2, 2))
         self.check('#!/bin/env my-interpreter\n'
                    '---\n'
                    '#comment\n'
                    '#!/bin/env my-interpreter\n'
                    '', conf,
                    problem1=(1, 2), problem2=(3, 2), problem3=(4, 2))
+        self.check('#! not a shebang\n',
+                   conf, problem1=(1, 2))
+        self.check('key:  #!/not/a/shebang\n',
+                   conf, problem1=(1, 8))
 
     def test_ignore_shebang(self):
         conf = ('comments:\n'
                 '  require-starting-space: true\n'
                 '  ignore-shebangs: true\n'
-                'comments-indentation: disable\n')
+                'comments-indentation: disable\n'
+                'document-start: disable\n')
         self.check('#!/bin/env my-interpreter\n', conf)
+        self.check('# comment\n'
+                   '#!/bin/env my-interpreter\n', conf,
+                   problem1=(2, 2))
         self.check('#!/bin/env my-interpreter\n'
                    '---\n'
                    '#comment\n'
-                   '#!/bin/env my-interpreter\n'
-                   '', conf,
+                   '#!/bin/env my-interpreter\n', conf,
                    problem2=(3, 2), problem3=(4, 2))
+        self.check('#! not a shebang\n',
+                   conf, problem1=(1, 2))
+        self.check('key:  #!/not/a/shebang\n',
+                   conf, problem1=(1, 8))
 
     def test_spaces_from_content(self):
         conf = ('comments:\n'

--- a/yamllint/rules/comments.py
+++ b/yamllint/rules/comments.py
@@ -64,6 +64,8 @@ Use this rule to control the position and formatting of comments.
 """
 
 
+import re
+
 from yamllint.linter import LintProblem
 
 
@@ -92,7 +94,8 @@ def check(conf, comment):
         if text_start < len(comment.buffer):
             if (conf['ignore-shebangs'] and
                     comment.line_no == 1 and
-                    comment.buffer[text_start] == '!'):
+                    comment.column_no == 1 and
+                    re.match(r'^!\S', comment.buffer[text_start:])):
                 return
             elif comment.buffer[text_start] not in (' ', '\n', '\0'):
                 column = comment.column_no + text_start - comment.pointer


### PR DESCRIPTION
Some usages of YAML (like Ansible) supports running the file as a script.

Support (by default) an ignore-shebangs setting for the comments module.


Fixes #116 - comments rule with require-starting-space: true should special case shebang