### PR TITLE
Lint documentation with doc8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,11 +7,12 @@ python:
   - 3.6
   - nightly
 install:
-  - pip install pyyaml coveralls flake8 flake8-import-order
+  - pip install pyyaml coveralls flake8 flake8-import-order doc8
   - if [[ $TRAVIS_PYTHON_VERSION != 2* ]]; then pip install sphinx; fi
   - pip install .
 script:
   - flake8 .
+  - if [[ $TRAVIS_PYTHON_VERSION != 2* ]]; then doc8 $(git ls-files '*.rst'); fi
   - yamllint --strict $(git ls-files '*.yaml' '*.yml')
   - coverage run --source=yamllint setup.py test
   - if [[ $TRAVIS_PYTHON_VERSION != 2* ]]; then

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -45,9 +45,9 @@ It can be chosen using:
 Extending the default configuration
 -----------------------------------
 
-When writing a custom configuration file, you don't need to redefine every rule.
-Just extend the ``default`` configuration (or any already-existing configuration
-file).
+When writing a custom configuration file, you don't need to redefine every
+rule. Just extend the ``default`` configuration (or any already-existing
+configuration file).
 
 For instance, if you just want to disable the ``comments-indentation`` rule,
 your file could look like this:
@@ -105,8 +105,8 @@ Problems detected by yamllint can be raised either as errors or as warnings.
 The CLI will output them (with different colors when using the ``colored``
 output format, or ``auto`` when run from a terminal).
 
-By default the script will exit with a return code ``1`` *only when* there is one or
-more error(s).
+By default the script will exit with a return code ``1`` *only when* there is
+one or more error(s).
 
 However if strict mode is enabled with the ``-s`` (or ``--strict``) option, the
 return code will be:

--- a/docs/disable_with_comments.rst
+++ b/docs/disable_with_comments.rst
@@ -4,9 +4,9 @@ Disable with comments
 Disabling checks for a specific line
 ------------------------------------
 
-To prevent yamllint from reporting problems for a specific line, add a directive
-comment (``# yamllint disable-line ...``) on that line, or on the line above.
-For instance:
+To prevent yamllint from reporting problems for a specific line, add a
+directive comment (``# yamllint disable-line ...``) on that line, or on the
+line above. For instance:
 
 .. code-block:: yaml
 
@@ -46,9 +46,9 @@ If you need to disable multiple rules, it is allowed to chain rules like this:
 Disabling checks for all (or part of) the file
 ----------------------------------------------
 
-To prevent yamllint from reporting problems for the whole file, or for a block of
-lines within the file, use ``# yamllint disable ...`` and ``# yamllint enable
-...`` directive comments. For instance:
+To prevent yamllint from reporting problems for the whole file, or for a block
+of lines within the file, use ``# yamllint disable ...`` and ``# yamllint
+enable ...`` directive comments. For instance:
 
 .. code-block:: yaml
 

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -68,9 +68,9 @@ The output will look like (colors are not displayed here):
    10:1      error    too many blank lines (4 > 2)  (empty-lines)
    11:4      error    too many spaces inside braces  (braces)
 
-By default, the output of yamllint is colored when run from a terminal, and pure
-text in other cases. Add the ``-f standard`` arguments to force non-colored output.
-Use the ``-f colored`` arguments to force colored output.
+By default, the output of yamllint is colored when run from a terminal, and
+pure text in other cases. Add the ``-f standard`` arguments to force
+non-colored output. Use the ``-f colored`` arguments to force colored output.
 
 Add the ``-f parsable`` arguments if you need an output format parsable by a
 machine (for instance for :doc:`syntax highlighting in text editors


### PR DESCRIPTION
### chore(CI): Lint RST (reStructuredText) files

---

### style(docs): Fix RST lint errors reported by doc8
