### PR TITLE
config: Do not require all rule options to be set

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -21,6 +21,7 @@ except ImportError:
 import os
 import shutil
 import sys
+import tempfile
 import unittest
 
 from tests.common import build_temp_workspace
@@ -54,13 +55,16 @@ class SimpleConfigTestCase(unittest.TestCase):
                                   '  this-one-does-not-exist: enable\n')
 
     def test_missing_option(self):
-        with self.assertRaisesRegexp(
-                config.YamlLintConfigError,
-                'invalid config: missing option "max-spaces-before" '
-                'for rule "colons"'):
-            config.YamlLintConfig('rules:\n'
+        c = config.YamlLintConfig('rules:\n'
+                                  '  colons: enable\n')
+        self.assertEqual(c.rules['colons']['max-spaces-before'], 0)
+        self.assertEqual(c.rules['colons']['max-spaces-after'], 1)
+
+        c = config.YamlLintConfig('rules:\n'
                                   '  colons:\n'
-                                  '    max-spaces-after: 1\n')
+                                  '    max-spaces-before: 9\n')
+        self.assertEqual(c.rules['colons']['max-spaces-before'], 9)
+        self.assertEqual(c.rules['colons']['max-spaces-after'], 1)
 
     def test_unknown_option(self):
         with self.assertRaisesRegexp(
@@ -111,16 +115,21 @@ class SimpleConfigTestCase(unittest.TestCase):
                                       '    indent-sequences: YES!\n'
                                       '    check-multi-line-strings: false\n')
 
+    def test_enable_disable_keywords(self):
+        c = config.YamlLintConfig('rules:\n'
+                                  '  colons: enable\n'
+                                  '  hyphens: disable\n')
+        self.assertEqual(c.rules['colons'], {'level': 'error',
+                                             'max-spaces-after': 1,
+                                             'max-spaces-before': 0})
+        self.assertEqual(c.rules['hyphens'], False)
+
     def test_validate_rule_conf(self):
         class Rule(object):
             ID = 'fake'
 
         self.assertFalse(config.validate_rule_conf(Rule, False))
-        self.assertFalse(config.validate_rule_conf(Rule, 'disable'))
-
         self.assertEqual(config.validate_rule_conf(Rule, {}),
-                         {'level': 'error'})
-        self.assertEqual(config.validate_rule_conf(Rule, 'enable'),
                          {'level': 'error'})
 
         config.validate_rule_conf(Rule, {'level': 'error'})
@@ -129,22 +138,22 @@ class SimpleConfigTestCase(unittest.TestCase):
                           config.validate_rule_conf, Rule, {'level': 'warn'})
 
         Rule.CONF = {'length': int}
+        Rule.DEFAULT = {'length': 80}
         config.validate_rule_conf(Rule, {'length': 8})
-        self.assertRaises(config.YamlLintConfigError,
-                          config.validate_rule_conf, Rule, {})
+        config.validate_rule_conf(Rule, {})
         self.assertRaises(config.YamlLintConfigError,
                           config.validate_rule_conf, Rule, {'height': 8})
 
         Rule.CONF = {'a': bool, 'b': int}
+        Rule.DEFAULT = {'a': True, 'b': -42}
         config.validate_rule_conf(Rule, {'a': True, 'b': 0})
-        self.assertRaises(config.YamlLintConfigError,
-                          config.validate_rule_conf, Rule, {'a': True})
-        self.assertRaises(config.YamlLintConfigError,
-                          config.validate_rule_conf, Rule, {'b': 0})
+        config.validate_rule_conf(Rule, {'a': True})
+        config.validate_rule_conf(Rule, {'b': 0})
         self.assertRaises(config.YamlLintConfigError,
                           config.validate_rule_conf, Rule, {'a': 1, 'b': 0})
 
         Rule.CONF = {'choice': (True, 88, 'str')}
+        Rule.DEFAULT = {'choice': 88}
         config.validate_rule_conf(Rule, {'choice': True})
         config.validate_rule_conf(Rule, {'choice': 88})
         config.validate_rule_conf(Rule, {'choice': 'str'})
@@ -156,8 +165,10 @@ class SimpleConfigTestCase(unittest.TestCase):
                           config.validate_rule_conf, Rule, {'choice': 'abc'})
 
         Rule.CONF = {'choice': (int, 'hardcoded')}
+        Rule.DEFAULT = {'choice': 1337}
         config.validate_rule_conf(Rule, {'choice': 42})
         config.validate_rule_conf(Rule, {'choice': 'hardcoded'})
+        config.validate_rule_conf(Rule, {})
         self.assertRaises(config.YamlLintConfigError,
                           config.validate_rule_conf, Rule, {'choice': False})
         self.assertRaises(config.YamlLintConfigError,
@@ -165,7 +176,7 @@ class SimpleConfigTestCase(unittest.TestCase):
 
 
 class ExtendedConfigTestCase(unittest.TestCase):
-    def test_extend_add_rule(self):
+    def test_extend_on_object(self):
         old = config.YamlLintConfig('rules:\n'
                                     '  colons:\n'
                                     '    max-spaces-before: 0\n'
@@ -182,60 +193,130 @@ class ExtendedConfigTestCase(unittest.TestCase):
 
         self.assertEqual(len(new.enabled_rules(None)), 2)
 
+    def test_extend_on_file(self):
+        with tempfile.NamedTemporaryFile('w') as f:
+            f.write('rules:\n'
+                    '  colons:\n'
+                    '    max-spaces-before: 0\n'
+                    '    max-spaces-after: 1\n')
+            f.flush()
+            c = config.YamlLintConfig('extends: ' + f.name + '\n'
+                                      'rules:\n'
+                                      '  hyphens:\n'
+                                      '    max-spaces-after: 2\n')
+
+        self.assertEqual(sorted(c.rules.keys()), ['colons', 'hyphens'])
+        self.assertEqual(c.rules['colons']['max-spaces-before'], 0)
+        self.assertEqual(c.rules['colons']['max-spaces-after'], 1)
+        self.assertEqual(c.rules['hyphens']['max-spaces-after'], 2)
+
+        self.assertEqual(len(c.enabled_rules(None)), 2)
+
     def test_extend_remove_rule(self):
-        old = config.YamlLintConfig('rules:\n'
-                                    '  colons:\n'
-                                    '    max-spaces-before: 0\n'
-                                    '    max-spaces-after: 1\n'
-                                    '  hyphens:\n'
-                                    '    max-spaces-after: 2\n')
-        new = config.YamlLintConfig('rules:\n'
-                                    '  colons: disable\n')
-        new.extend(old)
+        with tempfile.NamedTemporaryFile('w') as f:
+            f.write('rules:\n'
+                    '  colons:\n'
+                    '    max-spaces-before: 0\n'
+                    '    max-spaces-after: 1\n'
+                    '  hyphens:\n'
+                    '    max-spaces-after: 2\n')
+            f.flush()
+            c = config.YamlLintConfig('extends: ' + f.name + '\n'
+                                      'rules:\n'
+                                      '  colons: disable\n')
 
-        self.assertEqual(sorted(new.rules.keys()), ['colons', 'hyphens'])
-        self.assertFalse(new.rules['colons'])
-        self.assertEqual(new.rules['hyphens']['max-spaces-after'], 2)
+        self.assertEqual(sorted(c.rules.keys()), ['colons', 'hyphens'])
+        self.assertFalse(c.rules['colons'])
+        self.assertEqual(c.rules['hyphens']['max-spaces-after'], 2)
 
-        self.assertEqual(len(new.enabled_rules(None)), 1)
+        self.assertEqual(len(c.enabled_rules(None)), 1)
 
     def test_extend_edit_rule(self):
-        old = config.YamlLintConfig('rules:\n'
-                                    '  colons:\n'
-                                    '    max-spaces-before: 0\n'
-                                    '    max-spaces-after: 1\n'
-                                    '  hyphens:\n'
-                                    '    max-spaces-after: 2\n')
-        new = config.YamlLintConfig('rules:\n'
-                                    '  colons:\n'
-                                    '    max-spaces-before: 3\n'
-                                    '    max-spaces-after: 4\n')
-        new.extend(old)
+        with tempfile.NamedTemporaryFile('w') as f:
+            f.write('rules:\n'
+                    '  colons:\n'
+                    '    max-spaces-before: 0\n'
+                    '    max-spaces-after: 1\n'
+                    '  hyphens:\n'
+                    '    max-spaces-after: 2\n')
+            f.flush()
+            c = config.YamlLintConfig('extends: ' + f.name + '\n'
+                                      'rules:\n'
+                                      '  colons:\n'
+                                      '    max-spaces-before: 3\n'
+                                      '    max-spaces-after: 4\n')
 
-        self.assertEqual(sorted(new.rules.keys()), ['colons', 'hyphens'])
-        self.assertEqual(new.rules['colons']['max-spaces-before'], 3)
-        self.assertEqual(new.rules['colons']['max-spaces-after'], 4)
-        self.assertEqual(new.rules['hyphens']['max-spaces-after'], 2)
+        self.assertEqual(sorted(c.rules.keys()), ['colons', 'hyphens'])
+        self.assertEqual(c.rules['colons']['max-spaces-before'], 3)
+        self.assertEqual(c.rules['colons']['max-spaces-after'], 4)
+        self.assertEqual(c.rules['hyphens']['max-spaces-after'], 2)
 
-        self.assertEqual(len(new.enabled_rules(None)), 2)
+        self.assertEqual(len(c.enabled_rules(None)), 2)
 
     def test_extend_reenable_rule(self):
-        old = config.YamlLintConfig('rules:\n'
-                                    '  colons:\n'
-                                    '    max-spaces-before: 0\n'
-                                    '    max-spaces-after: 1\n'
-                                    '  hyphens: disable\n')
-        new = config.YamlLintConfig('rules:\n'
-                                    '  hyphens:\n'
-                                    '    max-spaces-after: 2\n')
-        new.extend(old)
+        with tempfile.NamedTemporaryFile('w') as f:
+            f.write('rules:\n'
+                    '  colons:\n'
+                    '    max-spaces-before: 0\n'
+                    '    max-spaces-after: 1\n'
+                    '  hyphens: disable\n')
+            f.flush()
+            c = config.YamlLintConfig('extends: ' + f.name + '\n'
+                                      'rules:\n'
+                                      '  hyphens:\n'
+                                      '    max-spaces-after: 2\n')
 
-        self.assertEqual(sorted(new.rules.keys()), ['colons', 'hyphens'])
-        self.assertEqual(new.rules['colons']['max-spaces-before'], 0)
-        self.assertEqual(new.rules['colons']['max-spaces-after'], 1)
-        self.assertEqual(new.rules['hyphens']['max-spaces-after'], 2)
+        self.assertEqual(sorted(c.rules.keys()), ['colons', 'hyphens'])
+        self.assertEqual(c.rules['colons']['max-spaces-before'], 0)
+        self.assertEqual(c.rules['colons']['max-spaces-after'], 1)
+        self.assertEqual(c.rules['hyphens']['max-spaces-after'], 2)
 
-        self.assertEqual(len(new.enabled_rules(None)), 2)
+        self.assertEqual(len(c.enabled_rules(None)), 2)
+
+    def test_extend_recursive_default_values(self):
+        with tempfile.NamedTemporaryFile('w') as f:
+            f.write('rules:\n'
+                    '  braces:\n'
+                    '    max-spaces-inside: 1248\n')
+            f.flush()
+            c = config.YamlLintConfig('extends: ' + f.name + '\n'
+                                      'rules:\n'
+                                      '  braces:\n'
+                                      '    min-spaces-inside-empty: 2357\n')
+
+        self.assertEqual(c.rules['braces']['min-spaces-inside'], 0)
+        self.assertEqual(c.rules['braces']['max-spaces-inside'], 1248)
+        self.assertEqual(c.rules['braces']['min-spaces-inside-empty'], 2357)
+        self.assertEqual(c.rules['braces']['max-spaces-inside-empty'], -1)
+
+        with tempfile.NamedTemporaryFile('w') as f:
+            f.write('rules:\n'
+                    '  colons:\n'
+                    '    max-spaces-before: 1337\n')
+            f.flush()
+            c = config.YamlLintConfig('extends: ' + f.name + '\n'
+                                      'rules:\n'
+                                      '  colons: enable\n')
+
+        self.assertEqual(c.rules['colons']['max-spaces-before'], 1337)
+        self.assertEqual(c.rules['colons']['max-spaces-after'], 1)
+
+        with tempfile.NamedTemporaryFile('w') as f1, \
+                tempfile.NamedTemporaryFile('w') as f2:
+            f1.write('rules:\n'
+                     '  colons:\n'
+                     '    max-spaces-before: 1337\n')
+            f1.flush()
+            f2.write('extends: ' + f1.name + '\n'
+                     'rules:\n'
+                     '  colons: disable\n')
+            f2.flush()
+            c = config.YamlLintConfig('extends: ' + f2.name + '\n'
+                                      'rules:\n'
+                                      '  colons: enable\n')
+
+        self.assertEqual(c.rules['colons']['max-spaces-before'], 0)
+        self.assertEqual(c.rules['colons']['max-spaces-after'], 1)
 
 
 class ExtendedLibraryConfigTestCase(unittest.TestCase):
@@ -267,6 +348,9 @@ class ExtendedLibraryConfigTestCase(unittest.TestCase):
         self.assertEqual(sorted(new.rules.keys()), sorted(old.rules.keys()))
         for rule in new.rules:
             self.assertEqual(new.rules[rule], old.rules[rule])
+        self.assertEqual(new.rules['empty-lines']['max'], 42)
+        self.assertEqual(new.rules['empty-lines']['max-start'], 43)
+        self.assertEqual(new.rules['empty-lines']['max-end'], 44)
 
     def test_extend_config_override_rule_partly(self):
         old = config.YamlLintConfig('extends: default')
@@ -280,6 +364,9 @@ class ExtendedLibraryConfigTestCase(unittest.TestCase):
         self.assertEqual(sorted(new.rules.keys()), sorted(old.rules.keys()))
         for rule in new.rules:
             self.assertEqual(new.rules[rule], old.rules[rule])
+        self.assertEqual(new.rules['empty-lines']['max'], 2)
+        self.assertEqual(new.rules['empty-lines']['max-start'], 42)
+        self.assertEqual(new.rules['empty-lines']['max-end'], 0)
 
 
 class IgnorePathConfigTestCase(unittest.TestCase):

--- a/yamllint/conf/default.yaml
+++ b/yamllint/conf/default.yaml
@@ -1,59 +1,28 @@
 ---
 
 rules:
-  braces:
-    min-spaces-inside: 0
-    max-spaces-inside: 0
-    min-spaces-inside-empty: -1
-    max-spaces-inside-empty: -1
-  brackets:
-    min-spaces-inside: 0
-    max-spaces-inside: 0
-    min-spaces-inside-empty: -1
-    max-spaces-inside-empty: -1
-  colons:
-    max-spaces-before: 0
-    max-spaces-after: 1
-  commas:
-    max-spaces-before: 0
-    min-spaces-after: 1
-    max-spaces-after: 1
+  braces: enable
+  brackets: enable
+  colons: enable
+  commas: enable
   comments:
     level: warning
-    require-starting-space: true
-    min-spaces-from-content: 2
   comments-indentation:
     level: warning
   document-end: disable
   document-start:
     level: warning
-    present: true
-  empty-lines:
-    max: 2
-    max-start: 0
-    max-end: 0
-  quoted-strings: disable
-  empty-values:
-    forbid-in-block-mappings: false
-    forbid-in-flow-mappings: false
-  hyphens:
-    max-spaces-after: 1
-  indentation:
-    spaces: consistent
-    indent-sequences: true
-    check-multi-line-strings: false
+  empty-lines: enable
+  empty-values: enable
+  hyphens: enable
+  indentation: enable
   key-duplicates: enable
   key-ordering: disable
-  line-length:
-    max: 80
-    allow-non-breakable-words: true
-    allow-non-breakable-inline-mappings: false
+  line-length: enable
   new-line-at-end-of-file: enable
-  new-lines:
-    type: unix
-  octal-values:
-    forbid-implicit-octal: false
-    forbid-explicit-octal: false
+  new-lines: enable
+  octal-values: enable
+  quoted-strings: disable
   trailing-spaces: enable
   truthy:
     level: warning

--- a/yamllint/rules/braces.py
+++ b/yamllint/rules/braces.py
@@ -101,6 +101,10 @@ CONF = {'min-spaces-inside': int,
         'max-spaces-inside': int,
         'min-spaces-inside-empty': int,
         'max-spaces-inside-empty': int}
+DEFAULT = {'min-spaces-inside': 0,
+           'max-spaces-inside': 0,
+           'min-spaces-inside-empty': -1,
+           'max-spaces-inside-empty': -1}
 
 
 def check(conf, token, prev, next, nextnext, context):

--- a/yamllint/rules/brackets.py
+++ b/yamllint/rules/brackets.py
@@ -102,6 +102,10 @@ CONF = {'min-spaces-inside': int,
         'max-spaces-inside': int,
         'min-spaces-inside-empty': int,
         'max-spaces-inside-empty': int}
+DEFAULT = {'min-spaces-inside': 0,
+           'max-spaces-inside': 0,
+           'min-spaces-inside-empty': -1,
+           'max-spaces-inside-empty': -1}
 
 
 def check(conf, token, prev, next, nextnext, context):

--- a/yamllint/rules/colons.py
+++ b/yamllint/rules/colons.py
@@ -79,6 +79,8 @@ ID = 'colons'
 TYPE = 'token'
 CONF = {'max-spaces-before': int,
         'max-spaces-after': int}
+DEFAULT = {'max-spaces-before': 0,
+           'max-spaces-after': 1}
 
 
 def check(conf, token, prev, next, nextnext, context):

--- a/yamllint/rules/commas.py
+++ b/yamllint/rules/commas.py
@@ -103,6 +103,9 @@ TYPE = 'token'
 CONF = {'max-spaces-before': int,
         'min-spaces-after': int,
         'max-spaces-after': int}
+DEFAULT = {'max-spaces-before': 0,
+           'min-spaces-after': 1,
+           'max-spaces-after': 1}
 
 
 def check(conf, token, prev, next, nextnext, context):

--- a/yamllint/rules/comments.py
+++ b/yamllint/rules/comments.py
@@ -68,6 +68,8 @@ ID = 'comments'
 TYPE = 'comment'
 CONF = {'require-starting-space': bool,
         'min-spaces-from-content': int}
+DEFAULT = {'require-starting-space': True,
+           'min-spaces-from-content': 2}
 
 
 def check(conf, comment):

--- a/yamllint/rules/document_end.py
+++ b/yamllint/rules/document_end.py
@@ -82,6 +82,7 @@ from yamllint.linter import LintProblem
 ID = 'document-end'
 TYPE = 'token'
 CONF = {'present': bool}
+DEFAULT = {'present': True}
 
 
 def check(conf, token, prev, next, nextnext, context):

--- a/yamllint/rules/document_start.py
+++ b/yamllint/rules/document_start.py
@@ -72,6 +72,7 @@ from yamllint.linter import LintProblem
 ID = 'document-start'
 TYPE = 'token'
 CONF = {'present': bool}
+DEFAULT = {'present': True}
 
 
 def check(conf, token, prev, next, nextnext, context):

--- a/yamllint/rules/empty_lines.py
+++ b/yamllint/rules/empty_lines.py
@@ -58,6 +58,9 @@ TYPE = 'line'
 CONF = {'max': int,
         'max-start': int,
         'max-end': int}
+DEFAULT = {'max': 2,
+           'max-start': 0,
+           'max-end': 0}
 
 
 def check(conf, line):

--- a/yamllint/rules/empty_values.py
+++ b/yamllint/rules/empty_values.py
@@ -75,6 +75,8 @@ ID = 'empty-values'
 TYPE = 'token'
 CONF = {'forbid-in-block-mappings': bool,
         'forbid-in-flow-mappings': bool}
+DEFAULT = {'forbid-in-block-mappings': False,
+           'forbid-in-flow-mappings': False}
 
 
 def check(conf, token, prev, next, nextnext, context):

--- a/yamllint/rules/hyphens.py
+++ b/yamllint/rules/hyphens.py
@@ -76,6 +76,7 @@ from yamllint.rules.common import spaces_after
 ID = 'hyphens'
 TYPE = 'token'
 CONF = {'max-spaces-after': int}
+DEFAULT = {'max-spaces-after': 1}
 
 
 def check(conf, token, prev, next, nextnext, context):

--- a/yamllint/rules/indentation.py
+++ b/yamllint/rules/indentation.py
@@ -201,6 +201,9 @@ TYPE = 'token'
 CONF = {'spaces': (int, 'consistent'),
         'indent-sequences': (bool, 'whatever', 'consistent'),
         'check-multi-line-strings': bool}
+DEFAULT = {'spaces': 'consistent',
+           'indent-sequences': True,
+           'check-multi-line-strings': False}
 
 ROOT, B_MAP, F_MAP, B_SEQ, F_SEQ, B_ENT, KEY, VAL = range(8)
 labels = ('ROOT', 'B_MAP', 'F_MAP', 'B_SEQ', 'F_SEQ', 'B_ENT', 'KEY', 'VAL')

--- a/yamllint/rules/key_duplicates.py
+++ b/yamllint/rules/key_duplicates.py
@@ -61,7 +61,6 @@ from yamllint.linter import LintProblem
 
 ID = 'key-duplicates'
 TYPE = 'token'
-CONF = {}
 
 MAP, SEQ = range(2)
 

--- a/yamllint/rules/key_ordering.py
+++ b/yamllint/rules/key_ordering.py
@@ -72,7 +72,6 @@ from yamllint.linter import LintProblem
 
 ID = 'key-ordering'
 TYPE = 'token'
-CONF = {}
 
 MAP, SEQ = range(2)
 

--- a/yamllint/rules/line_length.py
+++ b/yamllint/rules/line_length.py
@@ -102,6 +102,9 @@ TYPE = 'line'
 CONF = {'max': int,
         'allow-non-breakable-words': bool,
         'allow-non-breakable-inline-mappings': bool}
+DEFAULT = {'max': 80,
+           'allow-non-breakable-words': True,
+           'allow-non-breakable-inline-mappings': False}
 
 
 def check_inline_mapping(line):

--- a/yamllint/rules/new_lines.py
+++ b/yamllint/rules/new_lines.py
@@ -30,6 +30,7 @@ from yamllint.linter import LintProblem
 ID = 'new-lines'
 TYPE = 'line'
 CONF = {'type': ('unix', 'dos')}
+DEFAULT = {'type': 'unix'}
 
 
 def check(conf, line):

--- a/yamllint/rules/octal_values.py
+++ b/yamllint/rules/octal_values.py
@@ -66,6 +66,8 @@ ID = 'octal-values'
 TYPE = 'token'
 CONF = {'forbid-implicit-octal': bool,
         'forbid-explicit-octal': bool}
+DEFAULT = {'forbid-implicit-octal': False,
+           'forbid-explicit-octal': False}
 
 
 def check(conf, token, prev, next, nextnext, context):

--- a/yamllint/rules/quoted_strings.py
+++ b/yamllint/rules/quoted_strings.py
@@ -46,6 +46,7 @@ from yamllint.linter import LintProblem
 ID = 'quoted-strings'
 TYPE = 'token'
 CONF = {'quote-type': ('any', 'single', 'double')}
+DEFAULT = {'quote-type': 'any'}
 
 
 def check(conf, token, prev, next, nextnext, context):

--- a/yamllint/rules/truthy.py
+++ b/yamllint/rules/truthy.py
@@ -71,7 +71,6 @@ from yamllint.linter import LintProblem
 
 ID = 'truthy'
 TYPE = 'token'
-CONF = {}
 
 TRUTHY = ['YES', 'Yes', 'yes',
           'NO', 'No', 'no',


### PR DESCRIPTION
Before, it was required to specify all the options when customizing a
rule. For instance, one could use `empty-lines: enable` or `empty-lines:
{max: 1, max-start: 2, max-end: 2}`, but not just `empty-lines: {max:
1}` (it would fail with *invalid config: missing option "max-start" for
rule "empty-lines"*).

This was a minor problem for users, but it prevented the addition of new
options to existing rules, see [1] for an example. If a new option was
added, updating yamllint for all users that customize the rule would
produce a crash (*invalid config: missing option ...*).

To avoid that, let's embed default values inside the rules themselves,
instead of keeping them in `conf/default.yaml`.

This refactor should not have any impact on existing projects. I've
manually checked that it did not change the output of tests, on
different projects:
- ansible/ansible: `test/runner/ansible-test sanity --python 3.7 --test yamllint`
- ansible/molecule: `yamllint -s test/ molecule/`
- Neo23x0/sigma: `make test-yaml`
- markstory/lint-review: `yamllint .`

\[1]: https://github.com/adrienverge/yamllint/pull/151