### PR TITLE
docs(cli): Add a paragraph about standard input

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -50,6 +50,12 @@ You can also lint all YAML files in a whole directory:
 
  yamllint .
 
+Or lint a YAML stream from standard input:
+
+.. code:: bash
+
+ echo -e 'this: is\nvalid: YAML' | yamllint -
+
 The output will look like (colors are not displayed here):
 
 ::


### PR DESCRIPTION
See commit 05dfcbc "cli: Add command line option - to read from standard
input", cc @miguelbarao.