### PR TITLE
Enh/allowed truthy values/#150

### DIFF
--- a/tests/rules/test_truthy.py
+++ b/tests/rules/test_truthy.py
@@ -49,6 +49,68 @@ class TruthyTestCase(RuleTestCase):
                    problem3=(7, 3), problem4=(7, 7),
                    problem5=(8, 3), problem6=(8, 7))
 
+    def test_different_allowed_values(self):
+        conf = ('truthy:\n'
+                '  allowed-values: ["yes", "no"]\n')
+        self.check('---\n'
+                   'key1: foo\n'
+                   'key2: yes\n'
+                   'key3: bar\n'
+                   'key4: no\n', conf)
+        self.check('---\n'
+                   'key1: true\n'
+                   'key2: Yes\n'
+                   'key3: false\n'
+                   'key4: no\n'
+                   'key5: yes\n',
+                   conf,
+                   problem1=(2, 7), problem2=(3, 7),
+                   problem3=(4, 7))
+
+    def test_combined_allowed_values(self):
+        conf = ('truthy:\n'
+                '  allowed-values: ["yes", "no", "true", "false"]\n')
+        self.check('---\n'
+                   'key1: foo\n'
+                   'key2: yes\n'
+                   'key3: bar\n'
+                   'key4: no\n', conf)
+        self.check('---\n'
+                   'key1: true\n'
+                   'key2: Yes\n'
+                   'key3: false\n'
+                   'key4: no\n'
+                   'key5: yes\n',
+                   conf, problem1=(3, 7))
+
+    def test_no_allowed_values(self):
+        conf = ('truthy:\n'
+                '  allowed-values: []\n')
+        self.check('---\n'
+                   'key1: foo\n'
+                   'key2: bar\n', conf)
+        self.check('---\n'
+                   'key1: true\n'
+                   'key2: yes\n'
+                   'key3: false\n'
+                   'key4: no\n', conf,
+                   problem1=(2, 7), problem2=(3, 7),
+                   problem3=(4, 7), problem4=(5, 7))
+
+    def test_empty_string_allowed_values(self):
+        conf = ('truthy:\n'
+                '  allowed-values: ["", ""]\n')
+        self.check('---\n'
+                   'key1: foo\n'
+                   'key2: bar\n', conf)
+        self.check('---\n'
+                   'key1: true\n'
+                   'key2: yes\n'
+                   'key3: false\n'
+                   'key4: no\n', conf,
+                   problem1=(2, 7), problem2=(3, 7),
+                   problem3=(4, 7), problem4=(5, 7))
+
     def test_explicit_types(self):
         conf = 'truthy: enable\n'
         self.check('---\n'


### PR DESCRIPTION
This MR implements optional exceptions for truthy rule. 

Example usage (ansible):

```yaml
---
rules:
  line-length:
    max: 160
    level: warning
  truthy:
    allowed-values: ["yes", "no"]
```

Implemented in truthy rule by doing difference of sets of predefined banned values and configured allowed values.

Added 3 tests, all passed successfully.

Please feel free to review and suggest simplifications, or better variable names, which can be more standard and explanative.

Closes https://github.com/adrienverge/yamllint/issues/150