### PR TITLE
truthy: Validate options passed to 'allowed-values'

### DIFF
--- a/tests/rules/test_truthy.py
+++ b/tests/rules/test_truthy.py
@@ -97,20 +97,6 @@ class TruthyTestCase(RuleTestCase):
                    problem1=(2, 7), problem2=(3, 7),
                    problem3=(4, 7), problem4=(5, 7))
 
-    def test_empty_string_allowed_values(self):
-        conf = ('truthy:\n'
-                '  allowed-values: ["", ""]\n')
-        self.check('---\n'
-                   'key1: foo\n'
-                   'key2: bar\n', conf)
-        self.check('---\n'
-                   'key1: true\n'
-                   'key2: yes\n'
-                   'key3: false\n'
-                   'key4: no\n', conf,
-                   problem1=(2, 7), problem2=(3, 7),
-                   problem3=(4, 7), problem4=(5, 7))
-
     def test_explicit_types(self):
         conf = 'truthy: enable\n'
         self.check('---\n'

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -174,6 +174,25 @@ class SimpleConfigTestCase(unittest.TestCase):
         self.assertRaises(config.YamlLintConfigError,
                           config.validate_rule_conf, Rule, {'choice': 'abc'})
 
+        Rule.CONF = {'multiple': ['item1', 'item2', 'item3']}
+        Rule.DEFAULT = {'multiple': ['item1']}
+        config.validate_rule_conf(Rule, {'multiple': []})
+        config.validate_rule_conf(Rule, {'multiple': ['item2']})
+        config.validate_rule_conf(Rule, {'multiple': ['item2', 'item3']})
+        config.validate_rule_conf(Rule, {})
+        self.assertRaises(config.YamlLintConfigError,
+                          config.validate_rule_conf, Rule,
+                          {'multiple': 'item1'})
+        self.assertRaises(config.YamlLintConfigError,
+                          config.validate_rule_conf, Rule,
+                          {'multiple': ['']})
+        self.assertRaises(config.YamlLintConfigError,
+                          config.validate_rule_conf, Rule,
+                          {'multiple': ['item1', 4]})
+        self.assertRaises(config.YamlLintConfigError,
+                          config.validate_rule_conf, Rule,
+                          {'multiple': ['item4']})
+
 
 class ExtendedConfigTestCase(unittest.TestCase):
     def test_extend_on_object(self):

--- a/yamllint/config.py
+++ b/yamllint/config.py
@@ -134,12 +134,26 @@ def validate_rule_conf(rule, conf):
                 raise YamlLintConfigError(
                     'invalid config: unknown option "%s" for rule "%s"' %
                     (optkey, rule.ID))
+            # Example: CONF = {option: (bool, 'mixed')}
+            #          → {option: true}         → {option: mixed}
             if isinstance(options[optkey], tuple):
                 if (conf[optkey] not in options[optkey] and
                         type(conf[optkey]) not in options[optkey]):
                     raise YamlLintConfigError(
                         'invalid config: option "%s" of "%s" should be in %s'
                         % (optkey, rule.ID, options[optkey]))
+            # Example: CONF = {option: ['flag1', 'flag2']}
+            #          → {option: [flag1]}      → {option: [flag1, flag2]}
+            elif isinstance(options[optkey], list):
+                if (type(conf[optkey]) is not list or
+                        any(flag not in options[optkey]
+                            for flag in conf[optkey])):
+                    raise YamlLintConfigError(
+                        ('invalid config: option "%s" of "%s" should only '
+                         'contain values in %s')
+                        % (optkey, rule.ID, str(options[optkey])))
+            # Example: CONF = {option: int}
+            #          → {option: 42}
             else:
                 if not isinstance(conf[optkey], options[optkey]):
                     raise YamlLintConfigError(

--- a/yamllint/rules/truthy.py
+++ b/yamllint/rules/truthy.py
@@ -97,10 +97,6 @@ import yaml
 
 from yamllint.linter import LintProblem
 
-ID = 'truthy'
-TYPE = 'token'
-CONF = {'allowed-values': list}
-DEFAULT = {'allowed-values': ['true', 'false']}
 
 TRUTHY = ['YES', 'Yes', 'yes',
           'NO', 'No', 'no',
@@ -108,6 +104,12 @@ TRUTHY = ['YES', 'Yes', 'yes',
           'FALSE', 'False', 'false',
           'ON', 'On', 'on',
           'OFF', 'Off', 'off']
+
+
+ID = 'truthy'
+TYPE = 'token'
+CONF = {'allowed-values': list(TRUTHY)}
+DEFAULT = {'allowed-values': ['true', 'false']}
 
 
 def check(conf, token, prev, next, nextnext, context):


### PR DESCRIPTION
### config: Validate config options with list of enums

Allow rules to declare a list of valid values for an option.

For example, a rule like:

    CONF = {'allowed-values': list}

... allowed any value to be passed in the list (including bad ones).

It is now possible to declare:

    CONF = {'allowed-values': ['value1', 'value2', 'value3']}

... so that the list passed to the options must contain only values in
`['value1', 'value2', 'value3']`.

---

### truthy: Validate options passed to 'allowed-values'

Make sure values passed in allowed values are correct ones. This is
possible thanks to previous commit, and should prevent users from
writing incorrect configurations.

---

@Lirt for info.