### PR TITLE
add OpenBSD installation instructions

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -29,6 +29,12 @@ On FreeBSD:
 
   pkg install py36-yamllint
 
+On OpenBSD:
+
+.. code:: sh
+
+  doas pkg_add py3-yamllint
+
 Alternatively using pip, the Python package manager:
 
 .. code:: bash


### PR DESCRIPTION
Hi,

this diff adds the OpenBSD installation instructions only in docs/quickstart.rst.

Best regards.