### PR TITLE
Add Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+.git
+.gitignore
+.pre-commit-hooks.yaml
+.travis.yml
+docs
+tests

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM python:3-alpine3.10
+
+WORKDIR /
+COPY . /src
+RUN pip install --no-cache-dir /src && \
+    rm -rf ~/.cache/pip && \
+    rm -rf /src
+
+ENTRYPOINT [ "yamllint" ]
+CMD ["--version"]


### PR DESCRIPTION
Adds Dockerfile for official builds.

Can be easily paired with an [automated build on Docker Hub](https://docs.docker.com/docker-hub/builds/) or Travis CI to create fresh containers for each release.

This would be amazing for those of us who use yamllint in container-based CI platforms.

Closes #118