### PR TITLE
docs(configuration): improve `yaml-files` code example

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -125,9 +125,9 @@ configuration option. The default is:
 .. code-block:: yaml
 
  yaml-files:
- - '*.yaml'
- - '*.yml'
- - '.yamllint'
+   - '*.yaml'
+   - '*.yml'
+   - '.yamllint'
 
 The same rules as for ignoring paths apply (``.gitignore``-style path pattern,
 see below).


### PR DESCRIPTION
* A straight copy/paste of the existing example into the `.yamllint` file results in a `yamllint` error!