### PR TITLE
fix(default.yaml): disable `empty-values` & `octal-values` by default

### DIFF
--- a/tests/rules/test_octal_values.py
+++ b/tests/rules/test_octal_values.py
@@ -28,7 +28,9 @@ class OctalValuesTestCase(RuleTestCase):
         self.check('user-city: 0o10', conf)
 
     def test_implicit_octal_values(self):
-        conf = ('octal-values: {forbid-implicit-octal: true}\n'
+        conf = ('octal-values:\n'
+                '  forbid-implicit-octal: true\n'
+                '  forbid-explicit-octal: false\n'
                 'new-line-at-end-of-file: disable\n'
                 'document-start: disable\n')
         self.check('user-city: 010', conf, problem=(1, 15))
@@ -50,7 +52,9 @@ class OctalValuesTestCase(RuleTestCase):
                    '  - 0e3\n', conf)
 
     def test_explicit_octal_values(self):
-        conf = ('octal-values: {forbid-explicit-octal: true}\n'
+        conf = ('octal-values:\n'
+                '  forbid-implicit-octal: false\n'
+                '  forbid-explicit-octal: true\n'
                 'new-line-at-end-of-file: disable\n'
                 'document-start: disable\n')
         self.check('user-city: 0o10', conf, problem=(1, 16))

--- a/yamllint/conf/default.yaml
+++ b/yamllint/conf/default.yaml
@@ -18,7 +18,7 @@ rules:
   document-start:
     level: warning
   empty-lines: enable
-  empty-values: enable
+  empty-values: disable
   hyphens: enable
   indentation: enable
   key-duplicates: enable
@@ -26,7 +26,7 @@ rules:
   line-length: enable
   new-line-at-end-of-file: enable
   new-lines: enable
-  octal-values: enable
+  octal-values: disable
   quoted-strings: disable
   trailing-spaces: enable
   truthy:

--- a/yamllint/rules/empty_values.py
+++ b/yamllint/rules/empty_values.py
@@ -75,8 +75,8 @@ ID = 'empty-values'
 TYPE = 'token'
 CONF = {'forbid-in-block-mappings': bool,
         'forbid-in-flow-mappings': bool}
-DEFAULT = {'forbid-in-block-mappings': False,
-           'forbid-in-flow-mappings': False}
+DEFAULT = {'forbid-in-block-mappings': True,
+           'forbid-in-flow-mappings': True}
 
 
 def check(conf, token, prev, next, nextnext, context):

--- a/yamllint/rules/octal_values.py
+++ b/yamllint/rules/octal_values.py
@@ -66,8 +66,8 @@ ID = 'octal-values'
 TYPE = 'token'
 CONF = {'forbid-implicit-octal': bool,
         'forbid-explicit-octal': bool}
-DEFAULT = {'forbid-implicit-octal': False,
-           'forbid-explicit-octal': False}
+DEFAULT = {'forbid-implicit-octal': True,
+           'forbid-explicit-octal': True}
 
 
 def check(conf, token, prev, next, nextnext, context):


### PR DESCRIPTION
* Close #204 

---

@adrienverge This is the crux of the resolution.  What do you think about adding a note in the documentation, under each section (`empty-values` & `octal-values`)?  It could be used for the time being until existing users become informed that these values were in fact, not enabled.