### PR TITLE
Allow Disabling Non-Yaml Files

### DIFF
--- a/docs/disable_with_comments.rst
+++ b/docs/disable_with_comments.rst
@@ -73,3 +73,31 @@ It is possible, although not recommend, to disabled **all** rules:
 
 If you need to disable multiple rules, it is allowed to chain rules like this:
 ``# yamllint disable rule:hyphens rule:commas rule:indentation``.
+
+Disabling all checks for a file
+-------------------------------
+
+To prevent yamllint from reporting problems for a specific file, add the
+directive comment ``# yamllint disable-file`` as the first line of the file.
+For instance:
+
+.. code-block:: yaml
+
+ # yamllint disable-file
+ # The following mapping contains the same key twice, but I know what I'm doing:
+ key: value 1
+ key: value 2
+
+ - This line is waaaaaaaaaay too long but yamllint will not report anything about it.
+   This line will be checked by yamllint.
+
+or:
+
+.. code-block:: jinja
+
+ # yamllint disable-file
+ # This file is not valid YAML because it is a Jinja template
+ {% if extra_info %}
+ key1: value1
+ {% endif %}
+ key2: value2

--- a/tests/test_yamllint_directives.py
+++ b/tests/test_yamllint_directives.py
@@ -302,3 +302,104 @@ class YamllintDirectivesTestCase(RuleTestCase):
                    '    c: [x]\n',
                    conf,
                    problem=(6, 2, 'comments-indentation'))
+
+    def test_disable_file_directive(self):
+        conf = ('comments: {min-spaces-from-content: 2}\n'
+                'comments-indentation: {}\n')
+        self.check('# yamllint disable-file\n'
+                   '---\n'
+                   '- a: 1 # comment too close\n'
+                   '  b:\n'
+                   ' # wrong indentation\n'
+                   '    c: [x]\n',
+                   conf)
+        self.check('#    yamllint disable-file\n'
+                   '---\n'
+                   '- a: 1 # comment too close\n'
+                   '  b:\n'
+                   ' # wrong indentation\n'
+                   '    c: [x]\n',
+                   conf)
+        self.check('#yamllint disable-file\n'
+                   '---\n'
+                   '- a: 1 # comment too close\n'
+                   '  b:\n'
+                   ' # wrong indentation\n'
+                   '    c: [x]\n',
+                   conf)
+        self.check('#yamllint disable-file    \n'
+                   '---\n'
+                   '- a: 1 # comment too close\n'
+                   '  b:\n'
+                   ' # wrong indentation\n'
+                   '    c: [x]\n',
+                   conf)
+        self.check('---\n'
+                   '# yamllint disable-file\n'
+                   '- a: 1 # comment too close\n'
+                   '  b:\n'
+                   ' # wrong indentation\n'
+                   '    c: [x]\n',
+                   conf,
+                   problem1=(3, 8, 'comments'),
+                   problem2=(5, 2, 'comments-indentation'))
+        self.check('# yamllint disable-file: rules cannot be specified\n'
+                   '---\n'
+                   '- a: 1 # comment too close\n'
+                   '  b:\n'
+                   ' # wrong indentation\n'
+                   '    c: [x]\n',
+                   conf,
+                   problem1=(3, 8, 'comments'),
+                   problem2=(5, 2, 'comments-indentation'))
+        self.check('AAAA yamllint disable-file\n'
+                   '---\n'
+                   '- a: 1 # comment too close\n'
+                   '  b:\n'
+                   ' # wrong indentation\n'
+                   '    c: [x]\n',
+                   conf,
+                   problem1=(1, 1, 'document-start'),
+                   problem2=(3, 8, 'comments'),
+                   problem3=(5, 2, 'comments-indentation'))
+
+    def test_disable_file_directive_not_at_first_position(self):
+        self.check('# yamllint disable-file\n'
+                   '---\n'
+                   '- bad  : colon and spaces   \n',
+                   self.conf)
+        self.check('---\n'
+                   '# yamllint disable-file\n'
+                   '- bad  : colon and spaces   \n',
+                   self.conf,
+                   problem1=(3, 7, 'colons'),
+                   problem2=(3, 26, 'trailing-spaces'))
+
+    def test_disable_file_directive_with_syntax_error(self):
+        self.check('# This file is not valid YAML (it is a Jinja template)\n'
+                   '{% if extra_info %}\n'
+                   'key1: value1\n'
+                   '{% endif %}\n'
+                   'key2: value2\n',
+                   self.conf,
+                   problem=(2, 2, 'syntax'))
+        self.check('# yamllint disable-file\n'
+                   '# This file is not valid YAML (it is a Jinja template)\n'
+                   '{% if extra_info %}\n'
+                   'key1: value1\n'
+                   '{% endif %}\n'
+                   'key2: value2\n',
+                   self.conf)
+
+    def test_disable_file_directive_with_dos_lines(self):
+        self.check('# yamllint disable-file\r\n'
+                   '---\r\n'
+                   '- bad  : colon and spaces   \r\n',
+                   self.conf)
+        self.check('# yamllint disable-file\r\n'
+                   '# This file is not valid YAML (it is a Jinja template)\r\n'
+                   '{% if extra_info %}\r\n'
+                   'key1: value1\r\n'
+                   '{% endif %}\r\n'
+                   'key2: value2\r\n',
+                   self.conf)

--- a/yamllint/linter.py
+++ b/yamllint/linter.py
@@ -189,6 +189,10 @@ def _run(buffer, conf, filepath):
     assert hasattr(buffer, '__getitem__'), \
         '_run() argument must be a buffer, not a stream'
 
+    first_line = next(parser.line_generator(buffer)).content
+    if re.match(r'^#\s*yamllint disable-file\s*$', first_line):
+        return
+
     # If the document contains a syntax error, save it and yield it at the
     # right line
     syntax_error = get_syntax_error(buffer)


### PR DESCRIPTION
Allow disabling of a file, even if it is invalid yaml by including `yamllint disable-file` in the first line.