### PR TITLE
Filter output by problem level

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -116,8 +116,8 @@ return code will be:
  * ``1`` if one or more errors occur
  * ``2`` if no errors occur, but one or more warnings occur
 
-If the script is invoked with the ``-q`` (or ``--no-warning``) options, it will
-not output warning level problems, only error level.
+If the script is invoked with the ``--no-warnings`` option, it won't output
+warning level problems, only error level ones.
 
 YAML files extensions
 ---------------------

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -116,6 +116,9 @@ return code will be:
  * ``1`` if one or more errors occur
  * ``2`` if no errors occur, but one or more warnings occur
 
+If the script is invoked with the ``-q`` (or ``--no-warning``) options, it will
+not output warning level problems, only error level.
+
 YAML files extensions
 ---------------------
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -533,7 +533,7 @@ class CommandLineTestCase(unittest.TestCase):
             'mapping values are not allowed here\n'))
         self.assertEqual(err, '')
 
-    def test_run_supress_warnings(self):
+    def test_run_no_warnings(self):
         file = os.path.join(self.wd, 'a.yaml')
 
         sys.stdout, sys.stderr = StringIO(), StringIO()
@@ -558,3 +558,12 @@ class CommandLineTestCase(unittest.TestCase):
             cli.run((file, '--no-warnings', '-f', 'auto'))
 
         self.assertEqual(ctx.exception.code, 0)
+
+    def test_run_no_warnings_and_strict(self):
+        file = os.path.join(self.wd, 'warn.yaml')
+
+        sys.stdout, sys.stderr = StringIO(), StringIO()
+        with self.assertRaises(SystemExit) as ctx:
+            cli.run((file, '--no-warnings', '-s'))
+
+        self.assertEqual(ctx.exception.code, 2)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -532,3 +532,29 @@ class CommandLineTestCase(unittest.TestCase):
             'stdin:2:10: [error] syntax error: '
             'mapping values are not allowed here\n'))
         self.assertEqual(err, '')
+
+    def test_run_supress_warnings(self):
+        file = os.path.join(self.wd, 'a.yaml')
+
+        sys.stdout, sys.stderr = StringIO(), StringIO()
+        with self.assertRaises(SystemExit) as ctx:
+            cli.run((file, '--no-warnings', '-f', 'auto'))
+
+        self.assertEqual(ctx.exception.code, 1)
+
+        out, err = sys.stdout.getvalue(), sys.stderr.getvalue()
+        self.assertEqual(out, (
+            '%s\n'
+            '  2:4       error    trailing spaces  (trailing-spaces)\n'
+            '  3:4       error    no new line character at the end of file  '
+            '(new-line-at-end-of-file)\n'
+            '\n' % file))
+        self.assertEqual(err, '')
+
+        file = os.path.join(self.wd, 'warn.yaml')
+
+        sys.stdout, sys.stderr = StringIO(), StringIO()
+        with self.assertRaises(SystemExit) as ctx:
+            cli.run((file, '--no-warnings', '-f', 'auto'))
+
+        self.assertEqual(ctx.exception.code, 0)

--- a/yamllint/cli.py
+++ b/yamllint/cli.py
@@ -84,13 +84,13 @@ class Format(object):
         return line
 
 
-def show_problems(problems, file, args_format, quiet):
+def show_problems(problems, file, args_format, no_warn):
     max_level = 0
     first = True
 
     for problem in problems:
         max_level = max(max_level, PROBLEM_LEVELS[problem.level])
-        if quiet and (not problem.level == 'error'):
+        if no_warn and (problem.level != 'error'):
             continue
         if args_format == 'parsable':
             print(Format.parsable(problem, file))
@@ -135,7 +135,7 @@ def run(argv=None):
                         action='store_true',
                         help='return non-zero exit code on warnings '
                              'as well as errors')
-    parser.add_argument('-q', '--no-warnings',
+    parser.add_argument('--no-warnings',
                         action='store_true',
                         help='output only error level problems')
     parser.add_argument('-v', '--version', action='version',
@@ -182,7 +182,7 @@ def run(argv=None):
             print(e, file=sys.stderr)
             sys.exit(-1)
         prob_level = show_problems(problems, file, args_format=args.format,
-                                   quiet=args.no_warnings)
+                                   no_warn=args.no_warnings)
         max_level = max(max_level, prob_level)
 
     # read yaml from stdin
@@ -193,7 +193,7 @@ def run(argv=None):
             print(e, file=sys.stderr)
             sys.exit(-1)
         prob_level = show_problems(problems, 'stdin', args_format=args.format,
-                                   quiet=args.no_warnings)
+                                   no_warn=args.no_warnings)
         max_level = max(max_level, prob_level)
 
     if max_level == PROBLEM_LEVELS['error']:

--- a/yamllint/cli.py
+++ b/yamllint/cli.py
@@ -84,11 +84,14 @@ class Format(object):
         return line
 
 
-def show_problems(problems, file, args_format):
+def show_problems(problems, file, args_format, quiet):
     max_level = 0
     first = True
 
     for problem in problems:
+        max_level = max(max_level, PROBLEM_LEVELS[problem.level])
+        if quiet and (not problem.level == 'error'):
+            continue
         if args_format == 'parsable':
             print(Format.parsable(problem, file))
         elif args_format == 'colored' or \
@@ -102,7 +105,6 @@ def show_problems(problems, file, args_format):
                 print(file)
                 first = False
             print(Format.standard(problem, file))
-        max_level = max(max_level, PROBLEM_LEVELS[problem.level])
 
     if not first and args_format != 'parsable':
         print('')
@@ -133,6 +135,9 @@ def run(argv=None):
                         action='store_true',
                         help='return non-zero exit code on warnings '
                              'as well as errors')
+    parser.add_argument('-q', '--no-warnings',
+                        action='store_true',
+                        help='output only error level problems')
     parser.add_argument('-v', '--version', action='version',
                         version='{} {}'.format(APP_NAME, APP_VERSION))
 
@@ -176,7 +181,8 @@ def run(argv=None):
         except EnvironmentError as e:
             print(e, file=sys.stderr)
             sys.exit(-1)
-        prob_level = show_problems(problems, file, args_format=args.format)
+        prob_level = show_problems(problems, file, args_format=args.format,
+                                   quiet=args.no_warnings)
         max_level = max(max_level, prob_level)
 
     # read yaml from stdin
@@ -186,7 +192,8 @@ def run(argv=None):
         except EnvironmentError as e:
             print(e, file=sys.stderr)
             sys.exit(-1)
-        prob_level = show_problems(problems, 'stdin', args_format=args.format)
+        prob_level = show_problems(problems, 'stdin', args_format=args.format,
+                                   quiet=args.no_warnings)
         max_level = max(max_level, prob_level)
 
     if max_level == PROBLEM_LEVELS['error']:


### PR DESCRIPTION
Add configuration option `output-verbosity` to enable output filtering by problem level.

Aims to solve #86.