### PR TITLE
CI: Run tests on Python 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ python:
   - 3.5
   - 3.6
   - 3.7
+  - 3.8
   - nightly
 install:
   - pip install pyyaml coveralls flake8 flake8-import-order doc8


### PR DESCRIPTION
Python 3.8 was released in October 2019.