### PR TITLE
Read files in binary mode (fix #238)

### DIFF
--- a/yamllint/cli.py
+++ b/yamllint/cli.py
@@ -177,7 +177,7 @@ def run(argv=None):
     for file in find_files_recursively(args.files, conf):
         filepath = file[2:] if file.startswith('./') else file
         try:
-            with io.open(file, newline='') as f:
+            with io.open(file, mode='rb') as f:
                 problems = linter.run(f, conf, filepath)
         except EnvironmentError as e:
             print(e, file=sys.stderr)

--- a/yamllint/cli.py
+++ b/yamllint/cli.py
@@ -189,7 +189,7 @@ def run(argv=None):
     # read yaml from stdin
     if args.stdin:
         try:
-            problems = linter.run(sys.stdin, conf, '')
+            problems = linter.run(sys.stdin.buffer, conf, '')
         except EnvironmentError as e:
             print(e, file=sys.stderr)
             sys.exit(-1)

--- a/yamllint/parser.py
+++ b/yamllint/parser.py
@@ -105,8 +105,8 @@ def comments_between_tokens(token1, token2):
     pointer = token1.end_mark.pointer
 
     comment_before = None
-    for line in buf.split('\n'):
-        pos = line.find('#')
+    for line in buf.split(b'\n'):
+        pos = line.find(b'#')
         if pos != -1:
             comment = Comment(line_no, column_no + pos,
                               token1.end_mark.buffer, pointer + pos,

--- a/yamllint/parser.py
+++ b/yamllint/parser.py
@@ -50,9 +50,9 @@ class Comment(object):
         self.comment_before = comment_before
 
     def __str__(self):
-        end = self.buffer.find('\n', self.pointer)
+        end = self.buffer.find(b'\n', self.pointer)
         if end == -1:
-            end = self.buffer.find('\0', self.pointer)
+            end = self.buffer.find(b'\0', self.pointer)
         if end != -1:
             return self.buffer[self.pointer:end]
         return self.buffer[self.pointer:]
@@ -75,14 +75,14 @@ class Comment(object):
 def line_generator(buffer):
     line_no = 1
     cur = 0
-    next = buffer.find('\n')
+    next = buffer.find(b'\n')
     while next != -1:
         if next > 0 and buffer[next - 1] == '\r':
             yield Line(line_no, buffer, start=cur, end=next - 1)
         else:
             yield Line(line_no, buffer, start=cur, end=next)
         cur = next + 1
-        next = buffer.find('\n', cur)
+        next = buffer.find(b'\n', cur)
         line_no += 1
 
     yield Line(line_no, buffer, start=cur, end=len(buffer))


### PR DESCRIPTION
Resolves #238 

Limited testing shows this addresses the problem in #238 -- However, other testing has not been conducted (like if this reintroduces the 'newline problem' for Python3 or if files with a BOM are handled correctly; though hopefully that's in the travis test suite 😄 )