### PR TITLE
Add a "quote-percent" option to the "quoted-strings" rule

### DIFF
--- a/yamllint/rules/quoted_strings.py
+++ b/yamllint/rules/quoted_strings.py
@@ -72,9 +72,11 @@ from yamllint.linter import LintProblem
 ID = 'quoted-strings'
 TYPE = 'token'
 CONF = {'quote-type': ('any', 'single', 'double'),
-        'required': (True, False, 'only-when-needed')}
+        'required': (True, False, 'only-when-needed'),
+        'quote-percent': (True, False)}
 DEFAULT = {'quote-type': 'any',
-           'required': True}
+           'required': True,
+           'quote-percent': False}
 
 DEFAULT_SCALAR_TAG = u'tag:yaml.org,2002:str'
 START_TOKENS = {'#', '*', '!', '?', '@', '`', '&',
@@ -128,6 +130,9 @@ def check(conf, token, prev, next, nextnext, context):
             msg = "string value is not quoted with %s quotes" % (quote_type)
 
     elif not token.plain:
+
+        if conf['quote-percent']:
+            START_TOKENS.add('%')
 
         # Quotes are disallowed when not needed
         if (tag == DEFAULT_SCALAR_TAG and token.value


### PR DESCRIPTION
I really like the new `required: only-when-needed` option that has been added to the `quoted-strings` rule in version 1.21.0. Thank you for that.

When linting Symfony configuration files, there is a kind of false-positive though: Symfony requires placeholders such as `%kernel.project_dir%` or `%env(DATABASE_URL)%` to be quoted. Now even though this deviates from the YAML standard, it would be nice if yamllint would support this somehow.

This PR outlines a possible solution by adding a `quote-percent` option to the `quoted-strings` rule. Tests are still missing, because I wanted to discuss the implementation first. WDYT?