### PR TITLE
Add the "needed-extra-regex" option

### DIFF
--- a/tests/rules/test_quoted_strings.py
+++ b/tests/rules/test_quoted_strings.py
@@ -344,3 +344,24 @@ class QuotedTestCase(RuleTestCase):
                    '  "word 1\\\n'
                    '   word 2"\n',
                    conf, problem1=(9, 3))
+
+    def test_needed_extra_regex(self):
+        conf1 = 'quoted-strings: {quote-type: single, ' + \
+                                 'required: only-when-needed, ' + \
+                                 'needed-extra-regex: ""}\n'
+
+        self.check('---\n'
+                   'string1: foo\n'
+                   'string2: \'foo\'\n'                      # fails
+                   'string3: \'%foo\'\n',                    # fails
+                   conf1, problem1=(3, 10), problem2=(4, 10))
+
+        conf2 = 'quoted-strings: {quote-type: single, ' + \
+                                 'required: only-when-needed, ' + \
+                                 'needed-extra-regex: ^%.*$}\n'
+
+        self.check('---\n'
+                   'string1: foo\n'
+                   'string2: \'foo\'\n'                      # fails
+                   'string3: \'%foo\'\n',
+                   conf2, problem1=(3, 10))

--- a/tests/rules/test_quoted_strings.py
+++ b/tests/rules/test_quoted_strings.py
@@ -348,52 +348,28 @@ class QuotedTestCase(RuleTestCase):
     def test_needed_extra_regex_1(self):
         conf = 'quoted-strings: {quote-type: single, ' + \
                                 'required: only-when-needed, ' + \
-                                'needed-extra-regex: ^%.*%$}\n'
+                                'needed-extra-regex: ^http://}\n'
 
         self.check('---\n'
-                   'string1: \'$foo$\'\n'                    # fails
-                   'string2: \'%foo%\'\n',
+                   'string1: \'localhost\'\n'                # fails
+                   'string2: \'http://localhost\'\n',
                    conf, problem1=(2, 10))
         self.check('---\n'
                    'multiline string 1: |\n'
-                   '  \'%line 1\n'
-                   '  line 2%\'\n'
+                   '  localhost\n'
+                   '  http://localhost\n'
                    'multiline string 2: >\n'
-                   '  \'%word 1\n'
-                   '  word 2%\'\n'
+                   '  localhost\n'
+                   '  http://localhost\n'
                    'multiline string 3:\n'
-                   '  \'%word 1\n'
-                   '  word 2%\'\n'
+                   '  localhost\n'            # fails
+                   '  http://localhost\n'
                    'multiline string 4:\n'
-                   '  "\'%word 1\\\n'         # fails
-                   '   word 2%\'"\n',
+                   '  "localhost\\\n'
+                   '   http://localhost"\n',
                    conf, problem1=(12, 3))
 
     def test_needed_extra_regex_2(self):
-        conf = 'quoted-strings: {quote-type: single, ' + \
-                                'required: only-when-needed, ' + \
-                                'needed-extra-regex: ^%}\n'
-
-        self.check('---\n'
-                   'string1: \'$foo\'\n'                     # fails
-                   'string2: \'%foo\'\n',
-                   conf, problem1=(2, 10))
-        self.check('---\n'
-                   'multiline string 1: |\n'
-                   '  \'%line 1\n'
-                   '  line 2\'\n'
-                   'multiline string 2: >\n'
-                   '  \'%word 1\n'
-                   '  word 2\'\n'
-                   'multiline string 3:\n'
-                   '  \'%word 1\n'
-                   '  word 2\'\n'
-                   'multiline string 4:\n'
-                   '  "\'%word 1\\\n'         # fails
-                   '   word 2\'"\n',
-                   conf, problem1=(12, 3))
-
-    def test_needed_extra_regex_3(self):
         conf = 'quoted-strings: {quote-type: single, ' + \
                                 'required: only-when-needed, ' + \
                                 'needed-extra-regex: ;$}\n'
@@ -404,20 +380,20 @@ class QuotedTestCase(RuleTestCase):
                    conf, problem1=(2, 10))
         self.check('---\n'
                    'multiline string 1: |\n'
-                   '  \'line 1;\n'
-                   '  line 2\'\n'
+                   '  line 1;\n'
+                   '  line 2,\n'
                    'multiline string 2: >\n'
-                   '  \'word 1;\n'
-                   '  word 2\'\n'
+                   '  word 1;\n'
+                   '  word 2,\n'
                    'multiline string 3:\n'
-                   '  \'word 1;\n'            # fails
-                   '  word 2\'\n'
+                   '  word 1;\n'              # fails
+                   '  word 2,\n'
                    'multiline string 4:\n'
-                   '  "\'word 1;\\\n'         # fails
-                   '   word 2\'"\n',
-                   conf, problem1=(9, 3), problem2=(12, 3))
+                   '  "word 1;\\\n'
+                   '   word 2,"\n',
+                   conf, problem2=(12, 3))
 
-    def test_needed_extra_regex_4(self):
+    def test_needed_extra_regex_3(self):
         conf = 'quoted-strings: {quote-type: single, ' + \
                                 'required: only-when-needed, ' + \
                                 'needed-extra-regex: " "}\n'
@@ -428,15 +404,15 @@ class QuotedTestCase(RuleTestCase):
                    conf, problem1=(2, 10))
         self.check('---\n'
                    'multiline string 1: |\n'
-                   '  \'line1\n'
-                   '  line2\'\n'
+                   '  line1\n'
+                   '  line2\n'
                    'multiline string 2: >\n'
-                   '  \'word1\n'
-                   '  word2\'\n'
+                   '  word1\n'
+                   '  word2\n'
                    'multiline string 3:\n'
-                   '  \'word1\n'
-                   '  word2\'\n'
+                   '  word1\n'
+                   '  word2\n'
                    'multiline string 4:\n'
-                   '  "\'word1\\\n'           # fails
-                   '   word2\'"\n',
+                   '  "word1\\\n'             # fails
+                   '   word2"\n',
                    conf, problem1=(12, 3))

--- a/tests/rules/test_quoted_strings.py
+++ b/tests/rules/test_quoted_strings.py
@@ -420,7 +420,7 @@ class QuotedTestCase(RuleTestCase):
     def test_needed_extra_regex_4(self):
         conf = 'quoted-strings: {quote-type: single, ' + \
                                 'required: only-when-needed, ' + \
-                                'needed-extra-regex: ".+ .+"}\n'
+                                'needed-extra-regex: " "}\n'
 
         self.check('---\n'
                    'string1: \'foo\'\n'                      # fails

--- a/tests/rules/test_quoted_strings.py
+++ b/tests/rules/test_quoted_strings.py
@@ -345,23 +345,98 @@ class QuotedTestCase(RuleTestCase):
                    '   word 2"\n',
                    conf, problem1=(9, 3))
 
-    def test_needed_extra_regex(self):
-        conf1 = 'quoted-strings: {quote-type: single, ' + \
-                                 'required: only-when-needed, ' + \
-                                 'needed-extra-regex: ""}\n'
+    def test_needed_extra_regex_1(self):
+        conf = 'quoted-strings: {quote-type: single, ' + \
+                                'required: only-when-needed, ' + \
+                                'needed-extra-regex: ^%.*%$}\n'
 
         self.check('---\n'
-                   'string1: foo\n'
-                   'string2: \'foo\'\n'                      # fails
-                   'string3: \'%foo\'\n',                    # fails
-                   conf1, problem1=(3, 10), problem2=(4, 10))
+                   'string1: \'$foo$\'\n'                    # fails
+                   'string2: \'%foo%\'\n',
+                   conf, problem1=(2, 10))
+        self.check('---\n'
+                   'multiline string 1: |\n'
+                   '  \'%line 1\n'
+                   '  line 2%\'\n'
+                   'multiline string 2: >\n'
+                   '  \'%word 1\n'
+                   '  word 2%\'\n'
+                   'multiline string 3:\n'
+                   '  \'%word 1\n'
+                   '  word 2%\'\n'
+                   'multiline string 4:\n'
+                   '  "\'%word 1\\\n'         # fails
+                   '   word 2%\'"\n',
+                   conf, problem1=(12, 3))
 
-        conf2 = 'quoted-strings: {quote-type: single, ' + \
-                                 'required: only-when-needed, ' + \
-                                 'needed-extra-regex: ^%.*$}\n'
+    def test_needed_extra_regex_2(self):
+        conf = 'quoted-strings: {quote-type: single, ' + \
+                                'required: only-when-needed, ' + \
+                                'needed-extra-regex: ^%}\n'
 
         self.check('---\n'
-                   'string1: foo\n'
-                   'string2: \'foo\'\n'                      # fails
-                   'string3: \'%foo\'\n',
-                   conf2, problem1=(3, 10))
+                   'string1: \'$foo\'\n'                     # fails
+                   'string2: \'%foo\'\n',
+                   conf, problem1=(2, 10))
+        self.check('---\n'
+                   'multiline string 1: |\n'
+                   '  \'%line 1\n'
+                   '  line 2\'\n'
+                   'multiline string 2: >\n'
+                   '  \'%word 1\n'
+                   '  word 2\'\n'
+                   'multiline string 3:\n'
+                   '  \'%word 1\n'
+                   '  word 2\'\n'
+                   'multiline string 4:\n'
+                   '  "\'%word 1\\\n'         # fails
+                   '   word 2\'"\n',
+                   conf, problem1=(12, 3))
+
+    def test_needed_extra_regex_3(self):
+        conf = 'quoted-strings: {quote-type: single, ' + \
+                                'required: only-when-needed, ' + \
+                                'needed-extra-regex: ;$}\n'
+
+        self.check('---\n'
+                   'string1: \'foo,\'\n'                     # fails
+                   'string2: \'foo;\'\n',
+                   conf, problem1=(2, 10))
+        self.check('---\n'
+                   'multiline string 1: |\n'
+                   '  \'line 1;\n'
+                   '  line 2\'\n'
+                   'multiline string 2: >\n'
+                   '  \'word 1;\n'
+                   '  word 2\'\n'
+                   'multiline string 3:\n'
+                   '  \'word 1;\n'            # fails
+                   '  word 2\'\n'
+                   'multiline string 4:\n'
+                   '  "\'word 1;\\\n'         # fails
+                   '   word 2\'"\n',
+                   conf, problem1=(9, 3), problem2=(12, 3))
+
+    def test_needed_extra_regex_4(self):
+        conf = 'quoted-strings: {quote-type: single, ' + \
+                                'required: only-when-needed, ' + \
+                                'needed-extra-regex: ".+ .+"}\n'
+
+        self.check('---\n'
+                   'string1: \'foo\'\n'                      # fails
+                   'string2: \'foo bar\'\n',
+                   conf, problem1=(2, 10))
+        self.check('---\n'
+                   'multiline string 1: |\n'
+                   '  \'line1\n'
+                   '  line2\'\n'
+                   'multiline string 2: >\n'
+                   '  \'word1\n'
+                   '  word2\'\n'
+                   'multiline string 3:\n'
+                   '  \'word1\n'
+                   '  word2\'\n'
+                   'multiline string 4:\n'
+                   '  "\'word1\\\n'           # fails
+                   '   word2\'"\n',
+                   conf, problem1=(12, 3))

--- a/yamllint/rules/quoted_strings.py
+++ b/yamllint/rules/quoted_strings.py
@@ -26,6 +26,8 @@ used.
 * ``required`` defines whether using quotes in string values is required
   (``true``, default) or not (``false``), or only allowed when really needed
   (``only-when-needed``).
+* ``needed-extra-regex`` allows strings matching the given PCRE regex to be
+  quoted even when quoting is only allowed when really needed
 
 **Note**: Multi-line strings (with ``|`` or ``>``) will not be checked.
 
@@ -63,9 +65,22 @@ used.
    ::
 
     foo: 'bar'
+
+#. With ``quoted-strings: {quote-type: single, required: only-when-needed, needed-extra-regex: ^%.*%$ }``
+
+   the following code snippet would **PASS**:
+   ::
+
+    foo: '%bar%'
+
+   the following code snippet would **FAIL**:
+   ::
+
+    foo: 'bar'
 """
 
 import re
+
 import yaml
 
 from yamllint.linter import LintProblem
@@ -137,7 +152,7 @@ def check(conf, token, prev, next, nextnext, context):
                 and token.value[0] not in START_TOKENS):
             extra_regex = conf['needed-extra-regex']
 
-            if extra_regex == '' or not re.match(extra_regex, token.value):
+            if extra_regex == '' or not re.search(extra_regex, token.value):
                 msg = "string value is redundantly quoted with %s quotes" % (
                     quote_type)
 

--- a/yamllint/rules/quoted_strings.py
+++ b/yamllint/rules/quoted_strings.py
@@ -128,6 +128,7 @@ def check(conf, token, prev, next, nextnext, context):
 
     quote_type = conf['quote-type']
     required = conf['required']
+    extra_regex = conf['needed-extra-regex']
 
     # Completely relaxed about quotes (same as the rule being disabled)
     if required is False and quote_type == 'any':
@@ -150,12 +151,10 @@ def check(conf, token, prev, next, nextnext, context):
 
         # Quotes are disallowed when not needed
         if (tag == DEFAULT_SCALAR_TAG and token.value
-                and token.value[0] not in START_TOKENS):
-            extra_regex = conf['needed-extra-regex']
-
-            if extra_regex == '' or not re.search(extra_regex, token.value):
-                msg = "string value is redundantly quoted with %s quotes" % (
-                    quote_type)
+                and token.value[0] not in START_TOKENS and (extra_regex == ''
+                or not re.search(extra_regex, token.value))):
+            msg = "string value is redundantly quoted with %s quotes" % (
+                quote_type)
 
         # But when used need to match config
         elif token.style and not quote_match(quote_type, token.style):

--- a/yamllint/rules/quoted_strings.py
+++ b/yamllint/rules/quoted_strings.py
@@ -26,8 +26,8 @@ used.
 * ``required`` defines whether using quotes in string values is required
   (``true``, default) or not (``false``), or only allowed when really needed
   (``only-when-needed``).
-* ``needed-extra-regex`` allows strings matching the given PCRE regex to be
-  quoted even when quoting is only allowed when really needed
+* ``needed-extra-regex`` requires strings matching the given PCRE regex to be
+  quoted even when quoting is only allowed when really needed.
 
 **Note**: Multi-line strings (with ``|`` or ``>``) will not be checked.
 
@@ -77,6 +77,7 @@ used.
    ::
 
     foo: 'bar'
+    foo: %bar%
 """
 
 import re

--- a/yamllint/rules/quoted_strings.py
+++ b/yamllint/rules/quoted_strings.py
@@ -65,6 +65,7 @@ used.
     foo: 'bar'
 """
 
+import re
 import yaml
 
 from yamllint.linter import LintProblem
@@ -72,9 +73,11 @@ from yamllint.linter import LintProblem
 ID = 'quoted-strings'
 TYPE = 'token'
 CONF = {'quote-type': ('any', 'single', 'double'),
-        'required': (True, False, 'only-when-needed')}
+        'required': (True, False, 'only-when-needed'),
+        'needed-extra-regex': str}
 DEFAULT = {'quote-type': 'any',
-           'required': True}
+           'required': True,
+           'needed-extra-regex': ''}
 
 DEFAULT_SCALAR_TAG = u'tag:yaml.org,2002:str'
 START_TOKENS = {'#', '*', '!', '?', '@', '`', '&',
@@ -132,8 +135,11 @@ def check(conf, token, prev, next, nextnext, context):
         # Quotes are disallowed when not needed
         if (tag == DEFAULT_SCALAR_TAG and token.value
                 and token.value[0] not in START_TOKENS):
-            msg = "string value is redundantly quoted with %s quotes" % (
-                quote_type)
+            extra_regex = conf['needed-extra-regex']
+
+            if extra_regex == '' or not re.match(extra_regex, token.value):
+                msg = "string value is redundantly quoted with %s quotes" % (
+                    quote_type)
 
         # But when used need to match config
         elif token.style and not quote_match(quote_type, token.style):


### PR DESCRIPTION
This is the follow-up PR to #244, which adds the `needed-extra-regex` option to the `quoted-strings` rule.

```yaml
quoted-strings:
  required: only-when-needed
  needed-extra-regex: ^%.*$
```

This will suppress the "string value is redundantly quoted" warning for strings starting with a `%` character.