### PR TITLE
truthy rule: add `check-keys` option

### DIFF
--- a/tests/rules/test_truthy.py
+++ b/tests/rules/test_truthy.py
@@ -114,3 +114,29 @@ class TruthyTestCase(RuleTestCase):
                    'boolean5: !!bool off\n'
                    'boolean6: !!bool NO\n',
                    conf)
+
+    def test_check_keys_disabled(self):
+        conf = ('truthy:\n'
+                '  allowed-values: []\n'
+                '  check-keys: false\n'
+                'key-duplicates: disable\n')
+        self.check('---\n'
+                   'YES: 0\n'
+                   'Yes: 0\n'
+                   'yes: 0\n'
+                   'No: 0\n'
+                   'No: 0\n'
+                   'no: 0\n'
+                   'TRUE: 0\n'
+                   'True: 0\n'
+                   'true: 0\n'
+                   'FALSE: 0\n'
+                   'False: 0\n'
+                   'false: 0\n'
+                   'ON: 0\n'
+                   'On: 0\n'
+                   'on: 0\n'
+                   'OFF: 0\n'
+                   'Off: 0\n'
+                   'off: 0\n',
+                   conf)

--- a/yamllint/rules/truthy.py
+++ b/yamllint/rules/truthy.py
@@ -30,6 +30,9 @@ This can be useful to prevent surprises from YAML parsers transforming
   ``'False'``, ``'false'``, ``'YES'``, ``'Yes'``, ``'yes'``, ``'NO'``,
   ``'No'``, ``'no'``, ``'ON'``, ``'On'``, ``'on'``, ``'OFF'``, ``'Off'``,
   ``'off'``.
+* ``check-keys`` disables verification for keys in mappings. By default,
+  ``truthy`` rule applies to both keys and values. Set this option to ``false``
+  to prevent this.
 
 .. rubric:: Examples
 
@@ -92,6 +95,22 @@ This can be useful to prevent surprises from YAML parsers transforming
     - false
     - on
     - off
+
+#. With ``truthy: {check-keys: false}``
+
+   the following code snippet would **PASS**:
+   ::
+
+    yes:  1
+    on:   2
+    true: 3
+
+   the following code snippet would **FAIL**:
+   ::
+
+    yes:  Yes
+    on:   On
+    true: True
 """
 
 import yaml
@@ -109,12 +128,16 @@ TRUTHY = ['YES', 'Yes', 'yes',
 
 ID = 'truthy'
 TYPE = 'token'
-CONF = {'allowed-values': list(TRUTHY)}
-DEFAULT = {'allowed-values': ['true', 'false']}
+CONF = {'allowed-values': list(TRUTHY), 'check-keys': bool}
+DEFAULT = {'allowed-values': ['true', 'false'], 'check-keys': True}
 
 
 def check(conf, token, prev, next, nextnext, context):
     if prev and isinstance(prev, yaml.tokens.TagToken):
+        return
+
+    if (not conf['check-keys'] and isinstance(prev, yaml.tokens.KeyToken) and
+            isinstance(token, yaml.tokens.ScalarToken)):
         return
 
     if isinstance(token, yaml.tokens.ScalarToken):


### PR DESCRIPTION
Fixes: #158

This PR adds `check-keys` option to the truthy rule.

If `check-keys` option is disabled the rule applies only to the values. Default is enabled.