### PR TITLE
docs: Sunset Python 2

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -21,6 +21,10 @@ indentation, etc.
 
 Written in Python (compatible with Python 2 & 3).
 
+⚠ Python 2 upstream support stopped on January 1, 2020. yamllint will keep
+best-effort support for Python 2.7 until January 1, 2021. Passed that date,
+yamllint will drop all Python 2-related code.
+
 Documentation
 -------------
 


### PR DESCRIPTION
Keep supporting Python 2.7 for one extra year after upstream dropped it:
https://www.python.org/doc/sunset-python-2/