### PR TITLE
Fix quoted-strings rule broken on lists

### DIFF
--- a/tests/rules/test_quoted_strings.py
+++ b/tests/rules/test_quoted_strings.py
@@ -51,8 +51,14 @@ class QuotedTestCase(RuleTestCase):
                    'binary: !!binary binstring\n'
                    'integer: !!int intstring\n'
                    'boolean2: !!bool boolstring\n'
-                   'boolean3: !!bool "quotedboolstring"\n',
-                   conf, problem=(4, 10))
+                   'boolean3: !!bool "quotedboolstring"\n'
+                   'block-seq:\n'
+                   '  - foo\n'                               # fails
+                   '  - "foo"\n'
+                   'flow-seq: [foo, "foo"]\n'                # fails
+                   'flow-map: {a: foo, b: "foo"}\n',         # fails
+                   conf, problem1=(4, 10), problem2=(17, 5),
+                   problem3=(19, 12), problem4=(20, 15))
         self.check('---\n'
                    'multiline string 1: |\n'
                    '  line 1\n'
@@ -85,9 +91,16 @@ class QuotedTestCase(RuleTestCase):
                    'binary: !!binary binstring\n'
                    'integer: !!int intstring\n'
                    'boolean2: !!bool boolstring\n'
-                   'boolean3: !!bool "quotedboolstring"\n',
-                   conf, problem1=(4, 10), problem2=(5, 10),
-                   problem3=(6, 10), problem4=(7, 10))
+                   'boolean3: !!bool "quotedboolstring"\n'
+                   'block-seq:\n'
+                   '  - foo\n'                               # fails
+                   '  - "foo"\n'                             # fails
+                   'flow-seq: [foo, "foo"]\n'                # fails
+                   'flow-map: {a: foo, b: "foo"}\n',         # fails
+                   conf, problem1=(4, 10), problem2=(5, 10), problem3=(6, 10),
+                   problem4=(7, 10), problem5=(17, 5), problem6=(18, 5),
+                   problem7=(19, 12), problem8=(19, 17), problem9=(20, 15),
+                   problem10=(20, 23))
         self.check('---\n'
                    'multiline string 1: |\n'
                    '  line 1\n'
@@ -120,8 +133,14 @@ class QuotedTestCase(RuleTestCase):
                    'binary: !!binary binstring\n'
                    'integer: !!int intstring\n'
                    'boolean2: !!bool boolstring\n'
-                   'boolean3: !!bool "quotedboolstring"\n',
-                   conf, problem1=(4, 10), problem2=(8, 10))
+                   'boolean3: !!bool "quotedboolstring"\n'
+                   'block-seq:\n'
+                   '  - foo\n'                               # fails
+                   '  - "foo"\n'
+                   'flow-seq: [foo, "foo"]\n'                # fails
+                   'flow-map: {a: foo, b: "foo"}\n',         # fails
+                   conf, problem1=(4, 10), problem2=(8, 10), problem3=(17, 5),
+                   problem4=(19, 12), problem5=(20, 15))
         self.check('---\n'
                    'multiline string 1: |\n'
                    '  line 1\n'
@@ -189,7 +208,12 @@ class QuotedTestCase(RuleTestCase):
                    'binary: !!binary binstring\n'
                    'integer: !!int intstring\n'
                    'boolean2: !!bool boolstring\n'
-                   'boolean3: !!bool "quotedboolstring"\n',
+                   'boolean3: !!bool "quotedboolstring"\n'
+                   'block-seq:\n'
+                   '  - foo\n'                               # fails
+                   '  - "foo"\n'
+                   'flow-seq: [foo, "foo"]\n'                # fails
+                   'flow-map: {a: foo, b: "foo"}\n',         # fails
                    conf)
         self.check('---\n'
                    'multiline string 1: |\n'
@@ -223,9 +247,14 @@ class QuotedTestCase(RuleTestCase):
                    'binary: !!binary binstring\n'
                    'integer: !!int intstring\n'
                    'boolean2: !!bool boolstring\n'
-                   'boolean3: !!bool "quotedboolstring"\n',
-                   conf, problem2=(5, 10),
-                   problem3=(6, 10), problem4=(7, 10))
+                   'boolean3: !!bool "quotedboolstring"\n'
+                   'block-seq:\n'
+                   '  - foo\n'                               # fails
+                   '  - "foo"\n'
+                   'flow-seq: [foo, "foo"]\n'                # fails
+                   'flow-map: {a: foo, b: "foo"}\n',         # fails
+                   conf, problem1=(5, 10), problem2=(6, 10), problem3=(7, 10),
+                   problem4=(18, 5), problem5=(19, 17), problem6=(20, 23))
         self.check('---\n'
                    'multiline string 1: |\n'
                    '  line 1\n'
@@ -292,8 +321,14 @@ class QuotedTestCase(RuleTestCase):
                    'binary: !!binary binstring\n'
                    'integer: !!int intstring\n'
                    'boolean2: !!bool boolstring\n'
-                   'boolean3: !!bool "quotedboolstring"\n',
-                   conf, problem1=(5, 10), problem2=(8, 10))
+                   'boolean3: !!bool "quotedboolstring"\n'
+                   'block-seq:\n'
+                   '  - foo\n'
+                   '  - "foo"\n'                             # fails
+                   'flow-seq: [foo, "foo"]\n'                # fails
+                   'flow-map: {a: foo, b: "foo"}\n',         # fails
+                   conf, problem1=(5, 10), problem2=(8, 10), problem3=(18, 5),
+                   problem4=(19, 17), problem5=(20, 23))
         self.check('---\n'
                    'multiline string 1: |\n'
                    '  line 1\n'
@@ -327,9 +362,15 @@ class QuotedTestCase(RuleTestCase):
                    'binary: !!binary binstring\n'
                    'integer: !!int intstring\n'
                    'boolean2: !!bool boolstring\n'
-                   'boolean3: !!bool "quotedboolstring"\n',
-                   conf, problem1=(5, 10), problem2=(6, 10),
-                   problem3=(7, 10), problem4=(8, 10))
+                   'boolean3: !!bool "quotedboolstring"\n'
+                   'block-seq:\n'
+                   '  - foo\n'
+                   '  - "foo"\n'                             # fails
+                   'flow-seq: [foo, "foo"]\n'                # fails
+                   'flow-map: {a: foo, b: "foo"}\n',         # fails
+                   conf, problem1=(5, 10), problem2=(6, 10), problem3=(7, 10),
+                   problem4=(8, 10), problem5=(18, 5), problem6=(19, 17),
+                   problem7=(20, 23))
         self.check('---\n'
                    'multiline string 1: |\n'
                    '  line 1\n'

--- a/tests/rules/test_quoted_strings.py
+++ b/tests/rules/test_quoted_strings.py
@@ -137,76 +137,6 @@ class QuotedTestCase(RuleTestCase):
                    '   word 2"\n',
                    conf, problem1=(9, 3))
 
-    def test_disallow_redundant_quotes(self):
-        conf = 'quoted-strings: {required: only-when-needed}\n'
-
-        self.check('---\n'
-                   'boolean1: true\n'
-                   'number1: 123\n'
-                   'string1: foo\n'
-                   'string2: "foo"\n'                        # fails
-                   'string3: "true"\n'
-                   'string4: "123"\n'
-                   'string5: \'bar\'\n'                      # fails
-                   'string6: !!str genericstring\n'
-                   'string7: !!str 456\n'
-                   'string8: !!str "quotedgenericstring"\n'
-                   'binary: !!binary binstring\n'
-                   'integer: !!int intstring\n'
-                   'boolean2: !!bool boolstring\n'
-                   'boolean3: !!bool "quotedboolstring"\n',
-                   conf, problem1=(5, 10), problem2=(8, 10))
-        self.check('---\n'
-                   'multiline string 1: |\n'
-                   '  line 1\n'
-                   '  line 2\n'
-                   'multiline string 2: >\n'
-                   '  word 1\n'
-                   '  word 2\n'
-                   'multiline string 3:\n'
-                   '  word 1\n'
-                   '  word 2\n'
-                   'multiline string 4:\n'
-                   '  "word 1\\\n'            # fails
-                   '   word 2"\n',
-                   conf, problem1=(12, 3))
-
-    def test_disallow_redundant_single_quotes(self):
-        conf = 'quoted-strings: {quote-type: single, ' + \
-                                'required: only-when-needed}\n'
-
-        self.check('---\n'
-                   'boolean1: true\n'
-                   'number1: 123\n'
-                   'string1: foo\n'
-                   'string2: "foo"\n'                        # fails
-                   'string3: "true"\n'                       # fails
-                   'string4: "123"\n'                        # fails
-                   'string5: \'bar\'\n'                      # fails
-                   'string6: !!str genericstring\n'
-                   'string7: !!str 456\n'
-                   'string8: !!str "quotedgenericstring"\n'
-                   'binary: !!binary binstring\n'
-                   'integer: !!int intstring\n'
-                   'boolean2: !!bool boolstring\n'
-                   'boolean3: !!bool "quotedboolstring"\n',
-                   conf, problem1=(5, 10), problem2=(6, 10),
-                   problem3=(7, 10), problem4=(8, 10))
-        self.check('---\n'
-                   'multiline string 1: |\n'
-                   '  line 1\n'
-                   '  line 2\n'
-                   'multiline string 2: >\n'
-                   '  word 1\n'
-                   '  word 2\n'
-                   'multiline string 3:\n'
-                   '  word 1\n'
-                   '  word 2\n'
-                   'multiline string 4:\n'
-                   '  "word 1\\\n'            # fails
-                   '   word 2"\n',
-                   conf, problem1=(12, 3))
-
     def test_single_quotes_required(self):
         conf = 'quoted-strings: {quote-type: single, required: true}\n'
 
@@ -242,7 +172,7 @@ class QuotedTestCase(RuleTestCase):
                    '   word 2"\n',
                    conf, problem1=(9, 3), problem2=(12, 3))
 
-    def test_any_quotes_relaxed(self):
+    def test_any_quotes_not_required(self):
         conf = 'quoted-strings: {quote-type: any, required: false}\n'
 
         self.check('---\n'
@@ -276,7 +206,7 @@ class QuotedTestCase(RuleTestCase):
                    '   word 2"\n',
                    conf)
 
-    def test_single_quotes_relaxed(self):
+    def test_single_quotes_not_required(self):
         conf = 'quoted-strings: {quote-type: single, required: false}\n'
 
         self.check('---\n'
@@ -344,3 +274,73 @@ class QuotedTestCase(RuleTestCase):
                    '  "word 1\\\n'
                    '   word 2"\n',
                    conf, problem1=(9, 3))
+
+    def test_only_when_needed(self):
+        conf = 'quoted-strings: {required: only-when-needed}\n'
+
+        self.check('---\n'
+                   'boolean1: true\n'
+                   'number1: 123\n'
+                   'string1: foo\n'
+                   'string2: "foo"\n'                        # fails
+                   'string3: "true"\n'
+                   'string4: "123"\n'
+                   'string5: \'bar\'\n'                      # fails
+                   'string6: !!str genericstring\n'
+                   'string7: !!str 456\n'
+                   'string8: !!str "quotedgenericstring"\n'
+                   'binary: !!binary binstring\n'
+                   'integer: !!int intstring\n'
+                   'boolean2: !!bool boolstring\n'
+                   'boolean3: !!bool "quotedboolstring"\n',
+                   conf, problem1=(5, 10), problem2=(8, 10))
+        self.check('---\n'
+                   'multiline string 1: |\n'
+                   '  line 1\n'
+                   '  line 2\n'
+                   'multiline string 2: >\n'
+                   '  word 1\n'
+                   '  word 2\n'
+                   'multiline string 3:\n'
+                   '  word 1\n'
+                   '  word 2\n'
+                   'multiline string 4:\n'
+                   '  "word 1\\\n'            # fails
+                   '   word 2"\n',
+                   conf, problem1=(12, 3))
+
+    def test_only_when_needed_single_quotes(self):
+        conf = ('quoted-strings: {quote-type: single,\n'
+                '                 required: only-when-needed}\n')
+
+        self.check('---\n'
+                   'boolean1: true\n'
+                   'number1: 123\n'
+                   'string1: foo\n'
+                   'string2: "foo"\n'                        # fails
+                   'string3: "true"\n'                       # fails
+                   'string4: "123"\n'                        # fails
+                   'string5: \'bar\'\n'                      # fails
+                   'string6: !!str genericstring\n'
+                   'string7: !!str 456\n'
+                   'string8: !!str "quotedgenericstring"\n'
+                   'binary: !!binary binstring\n'
+                   'integer: !!int intstring\n'
+                   'boolean2: !!bool boolstring\n'
+                   'boolean3: !!bool "quotedboolstring"\n',
+                   conf, problem1=(5, 10), problem2=(6, 10),
+                   problem3=(7, 10), problem4=(8, 10))
+        self.check('---\n'
+                   'multiline string 1: |\n'
+                   '  line 1\n'
+                   '  line 2\n'
+                   'multiline string 2: >\n'
+                   '  word 1\n'
+                   '  word 2\n'
+                   'multiline string 3:\n'
+                   '  word 1\n'
+                   '  word 2\n'
+                   'multiline string 4:\n'
+                   '  "word 1\\\n'            # fails
+                   '   word 2"\n',
+                   conf, problem1=(12, 3))

--- a/yamllint/rules/quoted_strings.py
+++ b/yamllint/rules/quoted_strings.py
@@ -89,7 +89,10 @@ def quote_match(quote_type, token_style):
 
 def check(conf, token, prev, next, nextnext, context):
     if not (isinstance(token, yaml.tokens.ScalarToken) and
-            isinstance(prev, (yaml.ValueToken, yaml.TagToken))):
+            isinstance(prev, (yaml.BlockEntryToken, yaml.FlowEntryToken,
+                              yaml.FlowSequenceStartToken, yaml.TagToken,
+                              yaml.ValueToken))):
+
         return
 
     # Ignore explicit types, e.g. !!str testtest or !!int 42


### PR DESCRIPTION
### quoted-strings: Rename tests names for clarity

And move only-when-needed tests at the end for readability.

---

### quoted-strings: Fix broken rule for list items

The rule worked for values like:

```yaml
flow-map: {a: foo, b: "bar"}
block-map:
  a: foo
  b: "bar"
```

But not for:

```yaml
flow-seq: [foo, "bar"]
block-seq:
  - foo
  - "bar"
```

Also add tests to make sure there will be no regression.

Fixes: #208.