### PR TITLE
quoted-strings: Add extra-required and extra-allowed options

### DIFF
--- a/yamllint/config.py
+++ b/yamllint/config.py
@@ -157,11 +157,12 @@ def validate_rule_conf(rule, conf):
                     raise YamlLintConfigError(
                         'invalid config: option "%s" of "%s" should be in %s'
                         % (optkey, rule.ID, options[optkey]))
-            # Example: CONF = {option: ['flag1', 'flag2']}
-            #          → {option: [flag1]}      → {option: [flag1, flag2]}
+            # Example: CONF = {option: ['flag1', 'flag2', int]}
+            #          → {option: [flag1]}      → {option: [42, flag1, flag2]}
             elif isinstance(options[optkey], list):
                 if (type(conf[optkey]) is not list or
-                        any(flag not in options[optkey]
+                        any(flag not in options[optkey] and
+                            type(flag) not in options[optkey]
                             for flag in conf[optkey])):
                     raise YamlLintConfigError(
                         ('invalid config: option "%s" of "%s" should only '

--- a/yamllint/config.py
+++ b/yamllint/config.py
@@ -177,6 +177,12 @@ def validate_rule_conf(rule, conf):
         for optkey in options:
             if optkey not in conf:
                 conf[optkey] = options_default[optkey]
+
+        if hasattr(rule, 'VALIDATE'):
+            res = rule.VALIDATE(conf)
+            if res:
+                raise YamlLintConfigError('invalid config: %s: %s' %
+                                          (rule.ID, res))
     else:
         raise YamlLintConfigError(('invalid config: rule "%s": should be '
                                    'either "enable", "disable" or a dict')


### PR DESCRIPTION
### config: Allow rules to validate their configuration

---

### config: Allow generic types inside lists

For example it's possible to define a conf like:
```yaml
rule:
  foo: [str],
  bar: [int, bool, 'magic'],
```

---

### quoted-strings: Add options extra-required and extra-allowed

Add ability to:
- require strings to be quoted if they match a pattern (PCRE regex)
- allow quoted strings if they match a pattern, while `require:
  only-when-needed` is enforced.

Co-Authored-By: Leo Feyer (https://github.com/adrienverge/yamllint/pull/246)