### PR TITLE
Option to specify config file with environment variable

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -285,6 +285,26 @@ class CommandLineTestCase(unittest.TestCase):
             cli.run((os.path.join(self.wd, 'a.yaml'), ))
         self.assertEqual(ctx.returncode, 1)
 
+    def test_run_with_user_yamllintrc_config_file(self):
+        config = os.path.join(self.wd, 'fake-local-config')
+        self.addCleanup(os.remove, config)
+        self.addCleanup(os.environ.unsetenv, 'YAMLLINTRC')
+        os.environ['YAMLLINTRC'] = config
+
+        with open(config, 'w') as f:
+            f.write('rules: {trailing-spaces: disable}')
+
+        with RunContext(self) as ctx:
+            cli.run((os.path.join(self.wd, 'a.yaml'), ))
+        self.assertEqual(ctx.returncode, 0)
+
+        with open(config, 'w') as f:
+            f.write('rules: {trailing-spaces: enable}')
+
+        with RunContext(self) as ctx:
+            cli.run((os.path.join(self.wd, 'a.yaml'), ))
+        self.assertEqual(ctx.returncode, 1)
+
     def test_run_version(self):
         with RunContext(self) as ctx:
             cli.run(('--version', ))

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -288,7 +288,7 @@ class CommandLineTestCase(unittest.TestCase):
     def test_run_with_user_yamllintrc_config_file(self):
         config = os.path.join(self.wd, 'fake-local-config')
         self.addCleanup(os.remove, config)
-        self.addCleanup(os.environ.unsetenv, 'YAMLLINTRC')
+        self.addCleanup(os.environ.__delitem__, 'YAMLLINTRC')
         os.environ['YAMLLINTRC'] = config
 
         with open(config, 'w') as f:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -286,7 +286,7 @@ class CommandLineTestCase(unittest.TestCase):
             cli.run((os.path.join(self.wd, 'a.yaml'), ))
         self.assertEqual(ctx.returncode, 1)
 
-    def test_run_with_user_yamllintrc_config_file(self):
+    def test_run_with_user_yamllint_config_file_in_env(self):
         self.addCleanup(os.environ.__delitem__, 'YAMLLINT_CONFIG_FILE')
 
         with tempfile.NamedTemporaryFile('w') as f:

--- a/yamllint/cli.py
+++ b/yamllint/cli.py
@@ -144,8 +144,10 @@ def run(argv=None):
 
     args = parser.parse_args(argv)
 
+    if 'YAMLLINTRC' in os.environ:
+        user_global_config = os.path.expanduser(os.environ['YAMLLINTRC'])
     # User-global config is supposed to be in ~/.config/yamllint/config
-    if 'XDG_CONFIG_HOME' in os.environ:
+    elif 'XDG_CONFIG_HOME' in os.environ:
         user_global_config = os.path.join(
             os.environ['XDG_CONFIG_HOME'], 'yamllint', 'config')
     else:

--- a/yamllint/cli.py
+++ b/yamllint/cli.py
@@ -144,8 +144,9 @@ def run(argv=None):
 
     args = parser.parse_args(argv)
 
-    if 'YAMLLINTRC' in os.environ:
-        user_global_config = os.path.expanduser(os.environ['YAMLLINTRC'])
+    if 'YAMLLINT_CONFIG_FILE' in os.environ:
+        user_global_config = os.path.expanduser(
+            os.environ['YAMLLINT_CONFIG_FILE'])
     # User-global config is supposed to be in ~/.config/yamllint/config
     elif 'XDG_CONFIG_HOME' in os.environ:
         user_global_config = os.path.join(


### PR DESCRIPTION
Hey team-

This PR instructs the CLI to check the `YAMLLINTRC` environment variable for a global config path. For _most_ intents and purposes, this can be achieved with the `-c` flag, but I found a corner case where the environment variable is useful: I'd like to point my editor and my CI server at the same config file, and it's much easier to specify the variable once in something like a `.env` file than tweaking how both systems invoke `yamllint` individually.

I'm not married to the name "`YAMLLINTRC`"; please let me know if there's a better name (I've been working with pylint lately, so I think I subconsciously borrowed their convention). Also, please let me know if this is PR is the right place to make the corresponding update to the docs.

Thanks!