### PR TITLE
Add Python 3.8 to PyPI/trove classifier data

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,7 @@ setup(
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
         'Topic :: Software Development',
         'Topic :: Software Development :: Debuggers',
         'Topic :: Software Development :: Quality Assurance',


### PR DESCRIPTION
3.8 is now formally supported in .travis.yml
as of this commit.