### PR TITLE
Mention YAMLLINT_CONFIG_FILE in the documentation

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -16,6 +16,7 @@ following locations (by order of preference):
 
 - ``.yamllint``, ``.yamllint.yaml`` or ``.yamllint.yml`` in the current working
   directory
+- the file referenced by ``$YAMLLINT_CONFIG_FILE``, if set
 - ``$XDG_CONFIG_HOME/yamllint/config``
 - ``~/.config/yamllint/config``
 


### PR DESCRIPTION
Notes the new config file option from #255 in the docs.