### PR TITLE
Added flake8 ignores

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -4,6 +4,7 @@ universal = 1
 [flake8]
 import-order-style = pep8
 application-import-names = yamllint
+ignore = W503,W504
 
 [build_sphinx]
 all-files = 1


### PR DESCRIPTION
Avoid W503/W504 with current code as the current code not compliant
and they are contradictory.