### PR TITLE
Add "locale" config to key-ordering rule

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -189,3 +189,22 @@ Here is a more complex example:
      ignore: |
        *.ignore-trailing-spaces.yaml
        ascii-art/*
+
+Setting the locale
+------------------
+
+It is possible to set the ``locale`` option globally. This is passed to Python's
+`locale.setlocale
+<https://docs.python.org/3/library/locale.html#locale.setlocale>`_,
+so an empty string ``""`` will use the system default locale, while e.g.
+``"en_US.UTF-8"`` will use that. If unset, the default is ``"C.UTF-8"``.
+
+Currently this only affects the ``key-ordering`` rule. The default will order
+by Unicode code point number, while other locales will sort case and accents
+properly as well.
+
+.. code-block:: yaml
+
+ extends: default
+
+ locale: en_US.UTF-8

--- a/tests/rules/test_key_ordering.py
+++ b/tests/rules/test_key_ordering.py
@@ -14,6 +14,8 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import locale
+
 from tests.common import RuleTestCase
 
 
@@ -103,10 +105,6 @@ class KeyOrderingTestCase(RuleTestCase):
                    'haïr: true\n'
                    'hais: true\n', conf,
                    problem=(3, 1))
-        self.check('---\n'
-                   'haïr: true\n'
-                   'hais: true\n', conf,
-                   problem=(3, 1))
 
     def test_key_tokens_in_flow_sequences(self):
         conf = 'key-ordering: enable'
@@ -114,3 +112,39 @@ class KeyOrderingTestCase(RuleTestCase):
                    '[\n'
                    '  key: value, mappings, in, flow: sequence\n'
                    ']\n', conf)
+
+    def test_locale_case(self):
+        self.addCleanup(locale.setlocale, locale.LC_ALL, 'C.UTF-8')
+        try:
+            locale.setlocale(locale.LC_ALL, 'en_US.UTF-8')
+        except locale.Error:
+            self.skipTest('locale en_US.UTF-8 not available')
+        conf = ('key-ordering: enable')
+        self.check('---\n'
+                   't-shirt: 1\n'
+                   'T-shirt: 2\n'
+                   't-shirts: 3\n'
+                   'T-shirts: 4\n', conf)
+        self.check('---\n'
+                   't-shirt: 1\n'
+                   't-shirts: 2\n'
+                   'T-shirt: 3\n'
+                   'T-shirts: 4\n', conf,
+                   problem=(4, 1))
+
+    def test_locale_accents(self):
+        self.addCleanup(locale.setlocale, locale.LC_ALL, 'C.UTF-8')
+        try:
+            locale.setlocale(locale.LC_ALL, 'en_US.UTF-8')
+        except locale.Error:
+            self.skipTest('locale en_US.UTF-8 not available')
+        conf = ('key-ordering: enable')
+        self.check('---\n'
+                   'hair: true\n'
+                   'haïr: true\n'
+                   'hais: true\n'
+                   'haïssable: true\n', conf)
+        self.check('---\n'
+                   'hais: true\n'
+                   'haïr: true\n', conf,
+                   problem=(3, 1))

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -95,6 +95,13 @@ class CommandLineTestCase(unittest.TestCase):
             # dos line endings yaml
             'dos.yml': '---\r\n'
                        'dos: true',
+            # different key-ordering by locale
+            'c.yaml': '---\n'
+                      'A: true\n'
+                      'a: true',
+            'en.yaml': '---\n'
+                       'a: true\n'
+                       'A: true'
         })
 
     @classmethod
@@ -108,8 +115,10 @@ class CommandLineTestCase(unittest.TestCase):
         self.assertEqual(
             sorted(cli.find_files_recursively([self.wd], conf)),
             [os.path.join(self.wd, 'a.yaml'),
+             os.path.join(self.wd, 'c.yaml'),
              os.path.join(self.wd, 'dos.yml'),
              os.path.join(self.wd, 'empty.yml'),
+             os.path.join(self.wd, 'en.yaml'),
              os.path.join(self.wd, 's/s/s/s/s/s/s/s/s/s/s/s/s/s/s/file.yaml'),
              os.path.join(self.wd, 'sub/directory.yaml/empty.yml'),
              os.path.join(self.wd, 'sub/ok.yaml'),
@@ -146,6 +155,8 @@ class CommandLineTestCase(unittest.TestCase):
         self.assertEqual(
             sorted(cli.find_files_recursively([self.wd], conf)),
             [os.path.join(self.wd, 'a.yaml'),
+             os.path.join(self.wd, 'c.yaml'),
+             os.path.join(self.wd, 'en.yaml'),
              os.path.join(self.wd, 's/s/s/s/s/s/s/s/s/s/s/s/s/s/s/file.yaml'),
              os.path.join(self.wd, 'sub/ok.yaml'),
              os.path.join(self.wd, 'warn.yaml')]
@@ -175,8 +186,10 @@ class CommandLineTestCase(unittest.TestCase):
         self.assertEqual(
             sorted(cli.find_files_recursively([self.wd], conf)),
             [os.path.join(self.wd, 'a.yaml'),
+             os.path.join(self.wd, 'c.yaml'),
              os.path.join(self.wd, 'dos.yml'),
              os.path.join(self.wd, 'empty.yml'),
+             os.path.join(self.wd, 'en.yaml'),
              os.path.join(self.wd, 'no-yaml.json'),
              os.path.join(self.wd, 'non-ascii/éçäγλνπ¥/utf-8'),
              os.path.join(self.wd, 's/s/s/s/s/s/s/s/s/s/s/s/s/s/s/file.yaml'),
@@ -194,8 +207,10 @@ class CommandLineTestCase(unittest.TestCase):
         self.assertEqual(
             sorted(cli.find_files_recursively([self.wd], conf)),
             [os.path.join(self.wd, 'a.yaml'),
+             os.path.join(self.wd, 'c.yaml'),
              os.path.join(self.wd, 'dos.yml'),
              os.path.join(self.wd, 'empty.yml'),
+             os.path.join(self.wd, 'en.yaml'),
              os.path.join(self.wd, 'no-yaml.json'),
              os.path.join(self.wd, 'non-ascii/éçäγλνπ¥/utf-8'),
              os.path.join(self.wd, 's/s/s/s/s/s/s/s/s/s/s/s/s/s/s/file.yaml'),
@@ -315,6 +330,39 @@ class CommandLineTestCase(unittest.TestCase):
                 cli.run((os.path.join(self.wd, 'a.yaml'), ))
             self.assertEqual(ctx.returncode, 1)
 
+    def test_run_with_locale(self):
+        self.addCleanup(locale.setlocale, locale.LC_ALL, 'C.UTF-8')
+        try:
+            locale.setlocale(locale.LC_ALL, 'en_US.UTF-8')
+        except locale.Error:
+            self.skipTest('locale en_US.UTF-8 not available')
+
+        # C + en.yaml should fail
+        with RunContext(self) as ctx:
+            cli.run(('-d', 'rules: { key-ordering: enable }',
+                     os.path.join(self.wd, 'en.yaml')))
+        self.assertEqual(ctx.returncode, 1)
+
+        # en_US + en.yaml should pass
+        with RunContext(self) as ctx:
+            cli.run(('-d', 'locale: en_US.UTF-8\n'
+                           'rules: { key-ordering: enable }',
+                     os.path.join(self.wd, 'en.yaml')))
+        self.assertEqual(ctx.returncode, 0)
+
+        # en_US + c.yaml should fail
+        with RunContext(self) as ctx:
+            cli.run(('-d', 'locale: en_US.UTF-8\n'
+                           'rules: { key-ordering: enable }',
+                     os.path.join(self.wd, 'c.yaml')))
+        self.assertEqual(ctx.returncode, 1)
+
+        # C + c.yaml should pass
+        with RunContext(self) as ctx:
+            cli.run(('-d', 'rules: { key-ordering: enable }',
+                    os.path.join(self.wd, 'c.yaml')))
+        self.assertEqual(ctx.returncode, 0)
+
     def test_run_version(self):
         with RunContext(self) as ctx:
             cli.run(('--version', ))
@@ -372,15 +420,6 @@ class CommandLineTestCase(unittest.TestCase):
 
     def test_run_non_ascii_file(self):
         path = os.path.join(self.wd, 'non-ascii', 'éçäγλνπ¥', 'utf-8')
-
-        # Make sure the default localization conditions on this "system"
-        # support UTF-8 encoding.
-        loc = locale.getlocale()
-        try:
-            locale.setlocale(locale.LC_ALL, 'C.UTF-8')
-        except locale.Error:
-            locale.setlocale(locale.LC_ALL, 'en_US.UTF-8')
-        self.addCleanup(locale.setlocale, locale.LC_ALL, loc)
 
         with RunContext(self) as ctx:
             cli.run(('-f', 'parsable', path))

--- a/yamllint/cli.py
+++ b/yamllint/cli.py
@@ -18,6 +18,7 @@ from __future__ import print_function
 
 import argparse
 import io
+import locale
 import os
 import platform
 import sys
@@ -174,6 +175,8 @@ def run(argv=None):
     except YamlLintConfigError as e:
         print(e, file=sys.stderr)
         sys.exit(-1)
+
+    locale.setlocale(locale.LC_ALL, conf.locale)
 
     max_level = 0
 

--- a/yamllint/config.py
+++ b/yamllint/config.py
@@ -35,6 +35,8 @@ class YamlLintConfig(object):
         self.yaml_files = pathspec.PathSpec.from_lines(
             'gitwildmatch', ['*.yaml', '*.yml', '.yamllint'])
 
+        self.locale = 'C.UTF-8'
+
         if file is not None:
             with open(file) as f:
                 content = f.read()
@@ -110,6 +112,12 @@ class YamlLintConfig(object):
                     'should be a list of file patterns')
             self.yaml_files = pathspec.PathSpec.from_lines('gitwildmatch',
                                                            conf['yaml-files'])
+
+        if 'locale' in conf:
+            if not isinstance(conf['locale'], str):
+                raise YamlLintConfigError(
+                    'invalid config: locale should be a string')
+            self.locale = conf['locale']
 
     def validate(self):
         for id in self.rules:


### PR DESCRIPTION
Support sorting by locale with strcoll(). Properly handle case and accents.