### PR TITLE
Add Dockerfile and docker-compose.yml to run tests and linter

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+# Dockerfile to run the test suite and linter
+FROM python:slim
+RUN pip install flake8 flake8-import-order doc8 yamllint \
+ && apt-get update \
+ && apt-get install -y locales \
+ && rm -rf /var/lib/apt/lists/* \
+ && localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,18 @@
+# Docker Compose file to run the test suite and linter
+---
+version: "3"
+
+services:
+  test:
+    build: .
+    working_dir: /app
+    volumes:
+      - ./:/app
+    command: python setup.py test
+
+  lint:
+    build: .
+    working_dir: /app
+    volumes:
+      - ./:/app
+    command: sh -c "flake8 . ; yamllint --strict . ; doc8 -e .rst ."


### PR DESCRIPTION
Had trouble setting up a local dev environment on Windows while working on #280, so I created some Docker and Docker Compose files. In case you want to add those to your repo, I opened this PR.

Just run `docker-compose up test` and `docker-compose up lint` to run tests and the linter.