### PR TITLE
style: Fix 'noqa' for flake8 3.8.0

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -6,9 +6,9 @@ import sys
 import os
 from unittest.mock import MagicMock
 
-sys.path.insert(0, os.path.abspath('..'))  # noqa
+sys.path.insert(0, os.path.abspath('..'))
 
-from yamllint import __copyright__, APP_NAME, APP_VERSION
+from yamllint import __copyright__, APP_NAME, APP_VERSION  # noqa
 
 # -- General configuration ------------------------------------------------
 


### PR DESCRIPTION
There was a change in behavior of E402, see:
https://gitlab.com/pycqa/flake8/-/issues/638#note_345108633