### PR TITLE
docs: Add default values to rules with options

### DIFF
--- a/yamllint/rules/braces.py
+++ b/yamllint/rules/braces.py
@@ -28,7 +28,7 @@ Use this rule to control the number of spaces inside braces (``{`` and ``}``).
 * ``max-spaces-inside-empty`` defines the maximal number of spaces allowed
   inside empty braces.
 
-.. rubric:: Default values
+.. rubric:: Default values (when enabled)
 
 .. code-block:: yaml
 

--- a/yamllint/rules/braces.py
+++ b/yamllint/rules/braces.py
@@ -28,6 +28,17 @@ Use this rule to control the number of spaces inside braces (``{`` and ``}``).
 * ``max-spaces-inside-empty`` defines the maximal number of spaces allowed
   inside empty braces.
 
+.. rubric:: Default values
+
+.. code-block:: yaml
+
+ rules:
+   braces:
+     min-spaces-inside: 0
+     max-spaces-inside: 0
+     min-spaces-inside-empty: -1
+     max-spaces-inside-empty: -1
+
 .. rubric:: Examples
 
 #. With ``braces: {min-spaces-inside: 0, max-spaces-inside: 0}``

--- a/yamllint/rules/brackets.py
+++ b/yamllint/rules/brackets.py
@@ -29,7 +29,7 @@ Use this rule to control the number of spaces inside brackets (``[`` and
 * ``max-spaces-inside-empty`` defines the maximal number of spaces allowed
   inside empty brackets.
 
-.. rubric:: Default values
+.. rubric:: Default values (when enabled)
 
 .. code-block:: yaml
 

--- a/yamllint/rules/brackets.py
+++ b/yamllint/rules/brackets.py
@@ -29,6 +29,17 @@ Use this rule to control the number of spaces inside brackets (``[`` and
 * ``max-spaces-inside-empty`` defines the maximal number of spaces allowed
   inside empty brackets.
 
+.. rubric:: Default values
+
+.. code-block:: yaml
+
+ rules:
+   brackets:
+     min-spaces-inside: 0
+     max-spaces-inside: 0
+     min-spaces-inside-empty: -1
+     max-spaces-inside-empty: -1
+
 .. rubric:: Examples
 
 #. With ``brackets: {min-spaces-inside: 0, max-spaces-inside: 0}``

--- a/yamllint/rules/colons.py
+++ b/yamllint/rules/colons.py
@@ -24,6 +24,15 @@ Use this rule to control the number of spaces before and after colons (``:``).
 * ``max-spaces-after`` defines the maximal number of spaces allowed after
   colons (use ``-1`` to disable).
 
+.. rubric:: Default values
+
+.. code-block:: yaml
+
+ rules:
+   colons:
+     max-spaces-before: 0
+     max-spaces-after: 1
+
 .. rubric:: Examples
 
 #. With ``colons: {max-spaces-before: 0, max-spaces-after: 1}``

--- a/yamllint/rules/colons.py
+++ b/yamllint/rules/colons.py
@@ -24,7 +24,7 @@ Use this rule to control the number of spaces before and after colons (``:``).
 * ``max-spaces-after`` defines the maximal number of spaces allowed after
   colons (use ``-1`` to disable).
 
-.. rubric:: Default values
+.. rubric:: Default values (when enabled)
 
 .. code-block:: yaml
 

--- a/yamllint/rules/commas.py
+++ b/yamllint/rules/commas.py
@@ -26,6 +26,16 @@ Use this rule to control the number of spaces before and after commas (``,``).
 * ``max-spaces-after`` defines the maximal number of spaces allowed after
   commas (use ``-1`` to disable).
 
+.. rubric:: Default values
+
+.. code-block:: yaml
+
+ rules:
+   commas:
+     max-spaces-before: 0
+     min-spaces-after: 1
+     max-spaces-after: 1
+
 .. rubric:: Examples
 
 #. With ``commas: {max-spaces-before: 0}``

--- a/yamllint/rules/commas.py
+++ b/yamllint/rules/commas.py
@@ -26,7 +26,7 @@ Use this rule to control the number of spaces before and after commas (``,``).
 * ``max-spaces-after`` defines the maximal number of spaces allowed after
   commas (use ``-1`` to disable).
 
-.. rubric:: Default values
+.. rubric:: Default values (when enabled)
 
 .. code-block:: yaml
 

--- a/yamllint/rules/comments.py
+++ b/yamllint/rules/comments.py
@@ -28,7 +28,7 @@ Use this rule to control the position and formatting of comments.
   content. It defines the minimal required number of spaces between a comment
   and its preceding content.
 
-.. rubric:: Default values
+.. rubric:: Default values (when enabled)
 
 .. code-block:: yaml
 

--- a/yamllint/rules/comments.py
+++ b/yamllint/rules/comments.py
@@ -28,6 +28,16 @@ Use this rule to control the position and formatting of comments.
   content. It defines the minimal required number of spaces between a comment
   and its preceding content.
 
+.. rubric:: Default values
+
+.. code-block:: yaml
+
+ rules:
+   comments:
+     require-starting-space: true
+     ignore-shebangs: true
+     min-spaces-from-content: 2
+
 .. rubric:: Examples
 
 #. With ``comments: {require-starting-space: true}``

--- a/yamllint/rules/document_end.py
+++ b/yamllint/rules/document_end.py
@@ -22,6 +22,14 @@ Use this rule to require or forbid the use of document end marker (``...``).
 * Set ``present`` to ``true`` when the document end marker is required, or to
   ``false`` when it is forbidden.
 
+.. rubric:: Default values
+
+.. code-block:: yaml
+
+ rules:
+   document-end:
+     present: true
+
 .. rubric:: Examples
 
 #. With ``document-end: {present: true}``

--- a/yamllint/rules/document_end.py
+++ b/yamllint/rules/document_end.py
@@ -22,7 +22,7 @@ Use this rule to require or forbid the use of document end marker (``...``).
 * Set ``present`` to ``true`` when the document end marker is required, or to
   ``false`` when it is forbidden.
 
-.. rubric:: Default values
+.. rubric:: Default values (when enabled)
 
 .. code-block:: yaml
 

--- a/yamllint/rules/document_start.py
+++ b/yamllint/rules/document_start.py
@@ -22,7 +22,7 @@ Use this rule to require or forbid the use of document start marker (``---``).
 * Set ``present`` to ``true`` when the document start marker is required, or to
   ``false`` when it is forbidden.
 
-.. rubric:: Default values
+.. rubric:: Default values (when enabled)
 
 .. code-block:: yaml
 

--- a/yamllint/rules/document_start.py
+++ b/yamllint/rules/document_start.py
@@ -22,6 +22,14 @@ Use this rule to require or forbid the use of document start marker (``---``).
 * Set ``present`` to ``true`` when the document start marker is required, or to
   ``false`` when it is forbidden.
 
+.. rubric:: Default values
+
+.. code-block:: yaml
+
+ rules:
+   document-start:
+     present: true
+
 .. rubric:: Examples
 
 #. With ``document-start: {present: true}``

--- a/yamllint/rules/empty_lines.py
+++ b/yamllint/rules/empty_lines.py
@@ -25,6 +25,16 @@ Use this rule to set a maximal number of allowed consecutive blank lines.
 * ``max-end`` defines the maximal number of empty lines allowed at the end of
   the file.  This option takes precedence over ``max``.
 
+.. rubric:: Default values
+
+.. code-block:: yaml
+
+ rules:
+   empty-lines:
+     max: 2
+     max-start: 0
+     max-end: 0
+
 .. rubric:: Examples
 
 #. With ``empty-lines: {max: 1}``

--- a/yamllint/rules/empty_lines.py
+++ b/yamllint/rules/empty_lines.py
@@ -25,7 +25,7 @@ Use this rule to set a maximal number of allowed consecutive blank lines.
 * ``max-end`` defines the maximal number of empty lines allowed at the end of
   the file.  This option takes precedence over ``max``.
 
-.. rubric:: Default values
+.. rubric:: Default values (when enabled)
 
 .. code-block:: yaml
 

--- a/yamllint/rules/empty_values.py
+++ b/yamllint/rules/empty_values.py
@@ -23,7 +23,7 @@ Use this rule to prevent nodes with empty content, that implicitly result in
 * Use ``forbid-in-block-mappings`` to prevent empty values in block mappings.
 * Use ``forbid-in-flow-mappings`` to prevent empty values in flow mappings.
 
-.. rubric:: Default values
+.. rubric:: Default values (when enabled)
 
 .. code-block:: yaml
 

--- a/yamllint/rules/empty_values.py
+++ b/yamllint/rules/empty_values.py
@@ -23,6 +23,15 @@ Use this rule to prevent nodes with empty content, that implicitly result in
 * Use ``forbid-in-block-mappings`` to prevent empty values in block mappings.
 * Use ``forbid-in-flow-mappings`` to prevent empty values in flow mappings.
 
+.. rubric:: Default values
+
+.. code-block:: yaml
+
+ rules:
+   empty-values:
+     forbid-in-block-mappings: true
+     forbid-in-flow-mappings: true
+
 .. rubric:: Examples
 
 #. With ``empty-values: {forbid-in-block-mappings: true}``

--- a/yamllint/rules/hyphens.py
+++ b/yamllint/rules/hyphens.py
@@ -22,7 +22,7 @@ Use this rule to control the number of spaces after hyphens (``-``).
 * ``max-spaces-after`` defines the maximal number of spaces allowed after
   hyphens.
 
-.. rubric:: Default values
+.. rubric:: Default values (when enabled)
 
 .. code-block:: yaml
 

--- a/yamllint/rules/hyphens.py
+++ b/yamllint/rules/hyphens.py
@@ -22,6 +22,14 @@ Use this rule to control the number of spaces after hyphens (``-``).
 * ``max-spaces-after`` defines the maximal number of spaces allowed after
   hyphens.
 
+.. rubric:: Default values
+
+.. code-block:: yaml
+
+ rules:
+   hyphens:
+     max-spaces-after: 1
+
 .. rubric:: Examples
 
 #. With ``hyphens: {max-spaces-after: 1}``

--- a/yamllint/rules/indentation.py
+++ b/yamllint/rules/indentation.py
@@ -32,6 +32,16 @@ Use this rule to control the indentation.
 * ``check-multi-line-strings`` defines whether to lint indentation in
   multi-line strings. Set to ``true`` to enable, ``false`` to disable.
 
+.. rubric:: Default values
+
+.. code-block:: yaml
+
+ rules:
+   indentation:
+     spaces: consistent
+     indent-sequences: true
+     check-multi-line-strings: false
+
 .. rubric:: Examples
 
 #. With ``indentation: {spaces: 1}``

--- a/yamllint/rules/indentation.py
+++ b/yamllint/rules/indentation.py
@@ -32,13 +32,13 @@ Use this rule to control the indentation.
 * ``check-multi-line-strings`` defines whether to lint indentation in
   multi-line strings. Set to ``true`` to enable, ``false`` to disable.
 
-.. rubric:: Default values
+.. rubric:: Default values (when enabled)
 
 .. code-block:: yaml
 
  rules:
    indentation:
-     spaces: 'consistent'
+     spaces: consistent
      indent-sequences: true
      check-multi-line-strings: false
 

--- a/yamllint/rules/indentation.py
+++ b/yamllint/rules/indentation.py
@@ -38,7 +38,7 @@ Use this rule to control the indentation.
 
  rules:
    indentation:
-     spaces: consistent
+     spaces: 'consistent'
      indent-sequences: true
      check-multi-line-strings: false
 

--- a/yamllint/rules/line_length.py
+++ b/yamllint/rules/line_length.py
@@ -30,7 +30,7 @@ recommend running yamllint with Python 3.
 * ``allow-non-breakable-inline-mappings`` implies ``allow-non-breakable-words``
   and extends it to also allow non-breakable words in inline mappings.
 
-.. rubric:: Default values
+.. rubric:: Default values (when enabled)
 
 .. code-block:: yaml
 

--- a/yamllint/rules/line_length.py
+++ b/yamllint/rules/line_length.py
@@ -30,6 +30,16 @@ recommend running yamllint with Python 3.
 * ``allow-non-breakable-inline-mappings`` implies ``allow-non-breakable-words``
   and extends it to also allow non-breakable words in inline mappings.
 
+.. rubric:: Default values
+
+.. code-block:: yaml
+
+ rules:
+   line-length:
+     max: 80
+     allow-non-breakable-words: true
+     allow-non-breakable-inline-mappings: false
+
 .. rubric:: Examples
 
 #. With ``line-length: {max: 70}``

--- a/yamllint/rules/new_lines.py
+++ b/yamllint/rules/new_lines.py
@@ -22,13 +22,13 @@ Use this rule to force the type of new line characters.
 * Set ``type`` to ``unix`` to use UNIX-typed new line characters (``\\n``), or
   ``dos`` to use DOS-typed new line characters (``\\r\\n``).
 
-.. rubric:: Default values
+.. rubric:: Default values (when enabled)
 
 .. code-block:: yaml
 
  rules:
    new-lines:
-     type: 'unix'
+     type: unix
 """
 
 

--- a/yamllint/rules/new_lines.py
+++ b/yamllint/rules/new_lines.py
@@ -21,6 +21,14 @@ Use this rule to force the type of new line characters.
 
 * Set ``type`` to ``unix`` to use UNIX-typed new line characters (``\\n``), or
   ``dos`` to use DOS-typed new line characters (``\\r\\n``).
+
+.. rubric:: Default values
+
+.. code-block:: yaml
+
+ rules:
+   new-lines:
+     type: 'unix'
 """
 
 

--- a/yamllint/rules/octal_values.py
+++ b/yamllint/rules/octal_values.py
@@ -25,7 +25,7 @@ converted to ``8``.
 * Use ``forbid-implicit-octal`` to prevent numbers starting with ``0``.
 * Use ``forbid-explicit-octal`` to prevent numbers starting with ``0o``.
 
-.. rubric:: Default values
+.. rubric:: Default values (when enabled)
 
 .. code-block:: yaml
 

--- a/yamllint/rules/octal_values.py
+++ b/yamllint/rules/octal_values.py
@@ -20,6 +20,20 @@ start with ``0`` are interpreted as octal, but this is not always wanted.
 For instance ``010`` is the city code of Beijing, and should not be
 converted to ``8``.
 
+.. rubric:: Options
+
+* Use ``forbid-implicit-octal`` to prevent numbers starting with ``0``.
+* Use ``forbid-explicit-octal`` to prevent numbers starting with ``0o``.
+
+.. rubric:: Default values
+
+.. code-block:: yaml
+
+ rules:
+   octal-values:
+     forbid-implicit-octal: true
+     forbid-explicit-octal: true
+
 .. rubric:: Examples
 
 #. With ``octal-values: {forbid-implicit-octal: true}``

--- a/yamllint/rules/quoted_strings.py
+++ b/yamllint/rules/quoted_strings.py
@@ -34,13 +34,13 @@ used.
 
 **Note**: Multi-line strings (with ``|`` or ``>``) will not be checked.
 
-.. rubric:: Default values
+.. rubric:: Default values (when enabled)
 
 .. code-block:: yaml
 
  rules:
    quoted-strings:
-     quote-type: 'any'
+     quote-type: any
      required: true
      extra-required: []
      extra-allowed: []

--- a/yamllint/rules/quoted_strings.py
+++ b/yamllint/rules/quoted_strings.py
@@ -34,6 +34,17 @@ used.
 
 **Note**: Multi-line strings (with ``|`` or ``>``) will not be checked.
 
+.. rubric:: Default values
+
+.. code-block:: yaml
+
+ rules:
+   quoted-strings:
+     quote-type: 'any'
+     required: true
+     extra-required: []
+     extra-allowed: []
+
 .. rubric:: Examples
 
 #. With ``quoted-strings: {quote-type: any, required: true}``

--- a/yamllint/rules/truthy.py
+++ b/yamllint/rules/truthy.py
@@ -34,7 +34,7 @@ This can be useful to prevent surprises from YAML parsers transforming
   ``truthy`` rule applies to both keys and values. Set this option to ``false``
   to prevent this.
 
-.. rubric:: Default values
+.. rubric:: Default values (when enabled)
 
 .. code-block:: yaml
 

--- a/yamllint/rules/truthy.py
+++ b/yamllint/rules/truthy.py
@@ -34,6 +34,15 @@ This can be useful to prevent surprises from YAML parsers transforming
   ``truthy`` rule applies to both keys and values. Set this option to ``false``
   to prevent this.
 
+.. rubric:: Default values
+
+.. code-block:: yaml
+
+ rules:
+   truthy:
+     allowed-values: ['true', 'false']
+     check-keys: true
+
 .. rubric:: Examples
 
 #. With ``truthy: {}``


### PR DESCRIPTION
This adds default values to the documentation for all rules with options. The YAML blocks should themselves follow the defaults with indentation, spacing and quoting.

The `octal-values` rule did not have its options listed; they have been added.

This uses `.. code-block:: yaml` for the code blocks, which results in YAML syntax highlighting the same as on the Configuration page, but different from the example code snippets on the rules page, which use just `::`, resulting in default highlighting. Let me know what is preferred.

Closes #290 