### PR TITLE
Update commas.py

### DIFF
--- a/yamllint/rules/commas.py
+++ b/yamllint/rules/commas.py
@@ -76,7 +76,7 @@ Use this rule to control the number of spaces before and after commas (``,``).
    ::
 
     strange var:
-      [10, 20,30, {x: 1, y: 2}]
+      [10, 20, 30, {x: 1, y: 2}]
 
    the following code snippet would **FAIL**:
    ::


### PR DESCRIPTION
Error in the example snippet, it would NOT pass otherwise actually:
```
$ cat test.yml
strange var:
  [10, 20,30, {x: 1, y: 2}]

$ yamllint -d "{extends: default, rules: {commas: {min-spaces-after: 1, max-spaces-after: 1}}}" test.yml
test.yml
  1:1       warning  missing document start "---"  (document-start)
  2:11      error    too few spaces after comma  (commas)
```