### PR TITLE
enhancement: make possible to run tests and related stuff using tox

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+pathspec >= 0.5.3
+pyyaml

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,0 +1,2 @@
+flake8
+doc8

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,18 @@
+[tox]
+envlist = py27, py34, py35, py36, py37, py38
+
+[testenv]
+deps =
+    -r {toxinidir}/requirements.txt
+    -r {toxinidir}/tests/requirements.txt
+
+setenv =
+    PATH = {toxworkdir}/bin{:}{env:PATH}
+
+commands =
+    flake8 .
+    /bin/sh -c 'doc8 `git ls-files *.rst`'
+    /bin/sh -c 'yamllint --strict `git ls-files *.yaml *.yml`'
+    python setup.py test
+
+# vim:sw=4:ts=4:et:


### PR DESCRIPTION
Make possible to run tests (python setup.py test) and other related
stuff (flake8, doc8 and yamllint) using tox.

Signed-off-by: Satoru SATOH <satoru.satoh@gmail.com>