### PR TITLE
Add .eggs to ignored files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 __pycache__
 *.py[cod]
+/.eggs
 /docs/_build
 /dist
 /yamllint.egg-info


### PR DESCRIPTION
When running tests for #316, the directory `.eggs` was created. I don't know the Python world yet, maybe I did something wrong 😅️. Otherwise this will prevent commiting the directory accidentally.