### PR TITLE
Add 'forbid' configuration parameters to the braces and brackets rules

### DIFF
--- a/tests/rules/test_braces.py
+++ b/tests/rules/test_braces.py
@@ -31,6 +31,36 @@ class ColonTestCase(RuleTestCase):
                    'dict6: {  a: 1, b, c: 3 }\n'
                    'dict7: {   a: 1, b, c: 3 }\n', conf)
 
+    def test_forbid(self):
+        conf = ('braces:\n'
+                '  forbid: false\n')
+        self.check('---\n'
+                   'dict: {}\n', conf)
+        self.check('---\n'
+                   'dict: {a}\n', conf)
+        self.check('---\n'
+                   'dict: {a: 1}\n', conf)
+        self.check('---\n'
+                   'dict: {\n'
+                   '  a: 1\n'
+                   '}\n', conf)
+
+        conf = ('braces:\n'
+                '  forbid: true\n')
+        self.check('---\n'
+                   'dict:\n'
+                   '  a: 1\n', conf)
+        self.check('---\n'
+                   'dict: {}\n', conf, problem=(2, 8))
+        self.check('---\n'
+                   'dict: {a}\n', conf, problem=(2, 8))
+        self.check('---\n'
+                   'dict: {a: 1}\n', conf, problem=(2, 8))
+        self.check('---\n'
+                   'dict: {\n'
+                   '  a: 1\n'
+                   '}\n', conf, problem=(2, 8))
+
     def test_min_spaces(self):
         conf = ('braces:\n'
                 '  max-spaces-inside: -1\n'

--- a/tests/rules/test_brackets.py
+++ b/tests/rules/test_brackets.py
@@ -31,6 +31,35 @@ class ColonTestCase(RuleTestCase):
                    'array6: [  a, b, c ]\n'
                    'array7: [   a, b, c ]\n', conf)
 
+    def test_forbid(self):
+        conf = ('brackets:\n'
+                '  forbid: false\n')
+        self.check('---\n'
+                   'array: []\n', conf)
+        self.check('---\n'
+                   'array: [a, b]\n', conf)
+        self.check('---\n'
+                   'array: [\n'
+                   '  a,\n'
+                   '  b\n'
+                   ']\n', conf)
+
+        conf = ('brackets:\n'
+                '  forbid: true\n')
+        self.check('---\n'
+                   'array:\n'
+                   '  - a\n'
+                   '  - b\n', conf)
+        self.check('---\n'
+                   'array: []\n', conf, problem=(2, 9))
+        self.check('---\n'
+                   'array: [a, b]\n', conf, problem=(2, 9))
+        self.check('---\n'
+                   'array: [\n'
+                   '  a,\n'
+                   '  b\n'
+                   ']\n', conf, problem=(2, 9))
+
     def test_min_spaces(self):
         conf = ('brackets:\n'
                 '  max-spaces-inside: -1\n'


### PR DESCRIPTION
This is another try to accomplish the same thing in the PR #314 without adding new rules.

It's desirable for some use cases such like ansible playbooks to forbid flow collection styles as needed and this changs make that happen.

Of course, these should not be enabled for most use cases so that these configurations are disable by default.