### PR TITLE
Enhacements: simplify Travis-CI configuration using tox and enable running same tests locally

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,31 @@
+---
+# .. seealso:: https://github.com/ymyzk/tox-gh-actions
+#
+name: Tests
+# yamllint disable-line rule:truthy
+on:
+  - push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      max-parallel: 10
+      matrix:
+        python-version:
+          - 2.7
+          - 3.6
+          - 3.7
+          - 3.8
+
+    steps:
+      - uses: actions/checkout@v1
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: pip install tox tox-gh-actions
+      - name: Test with tox
+        run: tox
+
+# vim:sw=2:ts=2:et:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,17 +12,9 @@ env:
   - REMOVE_LOCALES=false
   - REMOVE_LOCALES=true
 install:
-  - pip install pyyaml coveralls flake8 flake8-import-order doc8
-  - if [[ $TRAVIS_PYTHON_VERSION != 2* ]]; then pip install sphinx; fi
-  - pip install .
+  - pip install tox-travis
   - if [[ $REMOVE_LOCALES = "true" ]]; then sudo rm -rf /usr/lib/locale/*; fi
 script:
-  - if [[ $TRAVIS_PYTHON_VERSION != nightly ]]; then flake8 .; fi
-  - if [[ $TRAVIS_PYTHON_VERSION != 2* ]]; then doc8 $(git ls-files '*.rst'); fi
-  - yamllint --strict $(git ls-files '*.yaml' '*.yml')
-  - coverage run --source=yamllint setup.py test
-  - if [[ $TRAVIS_PYTHON_VERSION != 2* ]]; then
-      python setup.py build_sphinx;
-    fi
+  - tox
 after_success:
   coveralls

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+pathspec >= 0.5.3
+pyyaml
+setuptools

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,0 +1,6 @@
+pyyaml
+coveralls
+flake8
+flake8-import-order
+doc8
+sphinx; python_version > '2.7'

--- a/tox.ini
+++ b/tox.ini
@@ -2,6 +2,13 @@
 envlist = py27, py34, py35, py36, py37, py38, nightly
 minversion = 3.15
 
+[gh-actions]
+python =
+    2.7: py27
+    3.6: py36
+    3.7: py37
+    3.8: py38
+
 [base]
 commands =
     - /bin/sh -c 'yamllint -c {toxinidir}/yamllint/conf/default.yaml --strict `git ls-files \*.yaml \*.yml`'

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,30 @@
+[tox]
+envlist = py27, py34, py35, py36, py37, py38, nightly
+minversion = 3.15
+
+[base]
+commands =
+    - /bin/sh -c 'yamllint -c {toxinidir}/yamllint/conf/default.yaml --strict `git ls-files \*.yaml \*.yml`'
+    coverage run --source=yamllint setup.py test
+
+[testenv]
+deps =
+    -r {toxinidir}/requirements.txt
+    -r {toxinidir}/tests/requirements.txt
+
+# https://tox.readthedocs.io/en/latest/config.html#substitution-for-values-from-other-sections
+commands =
+    /bin/sh -c 'doc8 `git ls-files \*.rst`'
+    {[base]commands}
+    python setup.py build_sphinx
+
+[testenv:py27]
+commands =
+    flake8 .
+    {[base]commands}
+
+# https://tox.readthedocs.io/en/latest/config.html#generative-section-names
+[testenv:py3{4,5,6,7,8}]
+commands =
+    flake8 .
+    {[testenv]commands}


### PR DESCRIPTION
This is another trial to add tox.ini to yamllint (previous one is pr #313).

This PR consists of the commits do followings.

1. Add tox.ini and requirements.txt for pip: This is similar to pr #313 but also should enables that developers can run almost same tests running in Travis-CI locally.
2. Simplify Travis-CI configuration utilizing tox.
3. Optional change to do similar CI using GitHub Actions instead of Travis-CI to reduce risk of strong dependency to specific CI web service only.