### PR TITLE
fix: add runtime dependency to setuptools

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -54,6 +54,7 @@ include_package_data = True
 install_requires =
   pathspec >= 0.5.3
   pyyaml
+  setuptools
 
 test_suite = tests
 


### PR DESCRIPTION
Because yamllint depends on pkg_resources.load_entry_point from
setuptools to make it worked, this runtime dependency to setuptools is
necessary to list.