### PR TITLE
Add support for GitHub annotations

### DIFF
--- a/docs/integration.rst
+++ b/docs/integration.rst
@@ -17,3 +17,37 @@ Here is an example, to add in your .pre-commit-config.yaml
     hooks:
       - id: yamllint
         args: [-c=/path/to/.yamllint]
+
+Integration with GitHub Actions
+-------------------------------
+
+yamllint auto-detects when it's running inside of `GitHub
+Actions<https://github.com/features/actions>` and automatically uses the suited
+output format to decorate code with linting errors automatically. You can also
+force the GitHub Actions output with ``yamllint --format github``.
+
+An example workflow using GitHub Actions:
+
+.. code:: yaml
+
+   ---
+   name: yamllint test
+
+   on: push
+
+   jobs:
+     test:
+       runs-on: ubuntu-latest
+       steps:
+         - uses: actions/checkout@v2
+
+         - name: Set up Python
+           uses: actions/setup-python@v2
+           with:
+             python-version: 3.8
+
+         - name: Install yamllint
+           run: pip install yamllint
+
+         - name: Lint YAML files
+           run: yamllint .

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -549,6 +549,20 @@ class CommandLineTestCase(unittest.TestCase):
         self.assertEqual(
             (ctx.returncode, ctx.stdout, ctx.stderr), (1, expected_out, ''))
 
+    def test_run_format_github(self):
+        path = os.path.join(self.wd, 'a.yaml')
+
+        with RunContext(self) as ctx:
+            cli.run((path, '--format', 'github'))
+        expected_out = (
+            '::error file=%s,line=2,col=4::[trailing-spaces] trailing'
+            ' spaces\n'
+            '::error file=%s,line=3,col=4::[new-line-at-end-of-file] no'
+            ' new line character at the end of file\n'
+            % (path, path))
+        self.assertEqual(
+            (ctx.returncode, ctx.stdout, ctx.stderr), (1, expected_out, ''))
+
     def test_run_read_from_stdin(self):
         # prepares stdin with an invalid yaml string so that we can check
         # for its specific error, and be assured that stdin was read

--- a/yamllint/cli.py
+++ b/yamllint/cli.py
@@ -109,7 +109,9 @@ def show_problems(problems, file, args_format, no_warn):
             continue
         if args_format == 'parsable':
             print(Format.parsable(problem, file))
-        elif args_format == 'github':
+        elif args_format == 'github' or (args_format == 'auto' and
+                                         'GITHUB_ACTIONS' in os.environ and
+                                         'GITHUB_WORKFLOW' in os.environ):
             print(Format.github(problem, file))
         elif args_format == 'colored' or \
                 (args_format == 'auto' and supports_color()):

--- a/yamllint/cli.py
+++ b/yamllint/cli.py
@@ -85,6 +85,19 @@ class Format(object):
             line += '  \033[2m(%s)\033[0m' % problem.rule
         return line
 
+    @staticmethod
+    def github(problem, filename):
+        line = '::'
+        line += problem.level
+        line += ' file=' + filename + ','
+        line += 'line=' + format(problem.line) + ','
+        line += 'col=' + format(problem.column)
+        line += '::'
+        if problem.rule:
+            line += '[' + problem.rule + '] '
+        line += problem.desc
+        return line
+
 
 def show_problems(problems, file, args_format, no_warn):
     max_level = 0
@@ -96,6 +109,8 @@ def show_problems(problems, file, args_format, no_warn):
             continue
         if args_format == 'parsable':
             print(Format.parsable(problem, file))
+        elif args_format == 'github':
+            print(Format.github(problem, file))
         elif args_format == 'colored' or \
                 (args_format == 'auto' and supports_color()):
             if first:
@@ -131,7 +146,8 @@ def run(argv=None):
                               action='store',
                               help='custom configuration (as YAML source)')
     parser.add_argument('-f', '--format',
-                        choices=('parsable', 'standard', 'colored', 'auto'),
+                        choices=('parsable', 'standard', 'colored', 'github',
+                                 'auto'),
                         default='auto', help='format for parsing output')
     parser.add_argument('-s', '--strict',
                         action='store_true',


### PR DESCRIPTION
This adds support for the output format that GitHub Actions can use to automatically annotate pull requests with linter failures.

I'm not very good with Python, so there are two ugly things I need recommendations for improving:
1. The two tests define the same magical output twice. I image I could go to one variable outside of the function definition, but I don't know where to put it
2. In the test for auto-detection I don't think the way I unset variables is as clean as it could be

I tested this by adding a bad YAML file (`a.yaml`) and then creating a GitHub Actions definition in `.github/workflows/test.yml` that looks like this

```yaml
---
name: yamllint test

# yamllint disable-line rule:truthy
on: push

jobs:
  test:
    runs-on: ubuntu-latest
    steps:
      - uses: actions/checkout@v2

      - name: Set up Python
        uses: actions/setup-python@v2
        with:
          python-version: 3.8

      - name: Setup Python venv
        run: |
          python -m venv ./.venv && . ./.venv/bin/activate &&
          pip install pyyaml coveralls flake8 flake8-import-order doc8
          pip install .
#      - name: Lint bad yaml file by explicitly telling it the format
#        run: |
#          source ./.venv/bin/activate &&
#          yamllint -f github a.yaml

      - name: Lint bad yaml file by autodetection
        run: |
          source ./.venv/bin/activate &&
          yamllint a.yaml
```
and it successfully outputs the annotations
![image](https://user-images.githubusercontent.com/6353225/93966430-b8de7400-fd32-11ea-9c41-6ded08aa0c3f.png)

