### PR TITLE
directives: Fix DOS lines messing with rule IDs

### DIFF
--- a/tests/test_yamllint_directives.py
+++ b/tests/test_yamllint_directives.py
@@ -232,6 +232,34 @@ class YamllintDirectivesTestCase(RuleTestCase):
                    problem1=(3, 18, 'trailing-spaces'),
                    problem2=(4, 8, 'colons'))
 
+    def test_disable_directive_with_rules_and_dos_lines(self):
+        conf = self.conf + 'new-lines: {type: dos}\n'
+        self.check('---\r\n'
+                   '- [valid , YAML]\r\n'
+                   '# yamllint disable rule:trailing-spaces\r\n'
+                   '- trailing spaces    \r\n'
+                   '- bad   : colon\r\n'
+                   '- [valid , YAML]\r\n'
+                   '# yamllint enable rule:trailing-spaces\r\n'
+                   '- bad  : colon and spaces   \r\n'
+                   '- [valid , YAML]\r\n',
+                   conf,
+                   problem1=(5, 8, 'colons'),
+                   problem2=(8, 7, 'colons'),
+                   problem3=(8, 26, 'trailing-spaces'))
+        self.check('---\r\n'
+                   '- [valid , YAML]\r\n'
+                   '- trailing spaces    \r\n'
+                   '- bad   : colon\r\n'
+                   '- [valid , YAML]\r\n'
+                   '# yamllint disable-line rule:colons\r\n'
+                   '- bad  : colon and spaces   \r\n'
+                   '- [valid , YAML]\r\n',
+                   conf,
+                   problem1=(3, 18, 'trailing-spaces'),
+                   problem2=(4, 8, 'colons'),
+                   problem3=(7, 26, 'trailing-spaces'))
+
     def test_directive_on_last_line(self):
         conf = 'new-line-at-end-of-file: {}'
         self.check('---\n'

--- a/yamllint/linter.py
+++ b/yamllint/linter.py
@@ -87,7 +87,8 @@ def get_cosmetic_problems(buffer, conf, filepath):
                 return  # this certainly wasn't a yamllint directive comment
 
             if re.match(r'^# yamllint disable( rule:\S+)*\s*$', comment):
-                rules = [item[5:] for item in comment[18:].split(' ')][1:]
+                items = comment[18:].rstrip().split(' ')
+                rules = [item[5:] for item in items][1:]
                 if len(rules) == 0:
                     self.rules = self.all_rules.copy()
                 else:
@@ -96,7 +97,8 @@ def get_cosmetic_problems(buffer, conf, filepath):
                             self.rules.add(id)
 
             elif re.match(r'^# yamllint enable( rule:\S+)*\s*$', comment):
-                rules = [item[5:] for item in comment[17:].split(' ')][1:]
+                items = comment[17:].rstrip().split(' ')
+                rules = [item[5:] for item in items][1:]
                 if len(rules) == 0:
                     self.rules.clear()
                 else:
@@ -114,7 +116,8 @@ def get_cosmetic_problems(buffer, conf, filepath):
                 return  # this certainly wasn't a yamllint directive comment
 
             if re.match(r'^# yamllint disable-line( rule:\S+)*\s*$', comment):
-                rules = [item[5:] for item in comment[23:].split(' ')][1:]
+                items = comment[23:].rstrip().split(' ')
+                rules = [item[5:] for item in items][1:]
                 if len(rules) == 0:
                     self.rules = self.all_rules.copy()
                 else:


### PR DESCRIPTION
Fixes #325 

The linter allows a directive to contain trailing whitespace characters like `\r`, but does not trim them before iterating on the rules. As a result, the last rule in the list contains the trailing whitespace characters and never matches any existing rule.

I added the necessary trimming, as well as a test with 2 checks to go along with it.