### PR TITLE
gitignore: Add /.eggs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ __pycache__
 /dist
 /yamllint.egg-info
 /build
+/.eggs


### PR DESCRIPTION
Quick PR to ignore the `/.eggs` folder, which appears to be generated every time the `python setup.py test` command is run.