### PR TITLE
tests: Stop using deprecated 'python setup.py test'

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ script:
   - if [[ $TRAVIS_PYTHON_VERSION != nightly ]]; then flake8 .; fi
   - if [[ $TRAVIS_PYTHON_VERSION != 2* ]]; then doc8 $(git ls-files '*.rst'); fi
   - yamllint --strict $(git ls-files '*.yaml' '*.yml')
-  - coverage run --source=yamllint setup.py test
+  - coverage run --source=yamllint -m unittest discover
   - if [[ $TRAVIS_PYTHON_VERSION != 2* ]]; then
       python setup.py build_sphinx;
     fi

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -13,7 +13,9 @@ Pull Request Process
 
    .. code:: bash
 
-    python setup.py test
+    pip install --user .
+    python -m unittest discover  # all tests...
+    python -m unittest tests/rules/test_commas.py  # or just some tests (faster)
 
 3. If you add code that should be tested, add tests.
 


### PR DESCRIPTION
Using `python setup.py test` is now deprecated [1], users are encouraged
to be explicit about the test command.

Running yamllint tests using the Python standard library (`unittest`)
can be done using:

    python -m unittest discover

Why not nose, tox or pytest? Because they would add a dependency, make
tests running more complicated and verbose for new users, and their
benefit is not worth for this simple project (only 2 runtime
dependencies: PyYAML and pathspec).

Resolves https://github.com/adrienverge/yamllint/issues/328.

\[1]: https://github.com/pypa/setuptools/pull/1878