### PR TITLE
tests: Replace deprecated aliases

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -246,19 +246,19 @@ class CommandLineTestCase(unittest.TestCase):
             cli.run(())
         self.assertNotEqual(ctx.returncode, 0)
         self.assertEqual(ctx.stdout, '')
-        self.assertRegexpMatches(ctx.stderr, r'^usage')
+        self.assertRegex(ctx.stderr, r'^usage')
 
         with RunContext(self) as ctx:
             cli.run(('--unknown-arg', ))
         self.assertNotEqual(ctx.returncode, 0)
         self.assertEqual(ctx.stdout, '')
-        self.assertRegexpMatches(ctx.stderr, r'^usage')
+        self.assertRegex(ctx.stderr, r'^usage')
 
         with RunContext(self) as ctx:
             cli.run(('-c', './conf.yaml', '-d', 'relaxed', 'file'))
         self.assertNotEqual(ctx.returncode, 0)
         self.assertEqual(ctx.stdout, '')
-        self.assertRegexpMatches(
+        self.assertRegex(
             ctx.stderr.splitlines()[-1],
             r'^yamllint: error: argument -d\/--config-data: '
             r'not allowed with argument -c\/--config-file$'
@@ -269,21 +269,21 @@ class CommandLineTestCase(unittest.TestCase):
             cli.run(('-', 'file'))
         self.assertNotEqual(ctx.returncode, 0)
         self.assertEqual(ctx.stdout, '')
-        self.assertRegexpMatches(ctx.stderr, r'^usage')
+        self.assertRegex(ctx.stderr, r'^usage')
 
     def test_run_with_bad_config(self):
         with RunContext(self) as ctx:
             cli.run(('-d', 'rules: {a: b}', 'file'))
         self.assertEqual(ctx.returncode, -1)
         self.assertEqual(ctx.stdout, '')
-        self.assertRegexpMatches(ctx.stderr, r'^invalid config: no such rule')
+        self.assertRegex(ctx.stderr, r'^invalid config: no such rule')
 
     def test_run_with_empty_config(self):
         with RunContext(self) as ctx:
             cli.run(('-d', '', 'file'))
         self.assertEqual(ctx.returncode, -1)
         self.assertEqual(ctx.stdout, '')
-        self.assertRegexpMatches(ctx.stderr, r'^invalid config: not a dict')
+        self.assertRegex(ctx.stderr, r'^invalid config: not a dict')
 
     def test_run_with_config_file(self):
         with open(os.path.join(self.wd, 'config'), 'w') as f:
@@ -386,7 +386,7 @@ class CommandLineTestCase(unittest.TestCase):
         with RunContext(self) as ctx:
             cli.run(('--version', ))
         self.assertEqual(ctx.returncode, 0)
-        self.assertRegexpMatches(ctx.stdout + ctx.stderr, r'yamllint \d+\.\d+')
+        self.assertRegex(ctx.stdout + ctx.stderr, r'yamllint \d+\.\d+')
 
     def test_run_non_existing_file(self):
         path = os.path.join(self.wd, 'i-do-not-exist.yaml')
@@ -395,7 +395,7 @@ class CommandLineTestCase(unittest.TestCase):
             cli.run(('-f', 'parsable', path))
         self.assertEqual(ctx.returncode, -1)
         self.assertEqual(ctx.stdout, '')
-        self.assertRegexpMatches(ctx.stderr, r'No such file or directory')
+        self.assertRegex(ctx.stderr, r'No such file or directory')
 
     def test_run_one_problem_file(self):
         path = os.path.join(self.wd, 'a.yaml')

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -71,6 +71,11 @@ class CommandLineTestCase(unittest.TestCase):
     def setUpClass(cls):
         super(CommandLineTestCase, cls).setUpClass()
 
+        # https://docs.python.org/3/library/unittest.html#deprecated-aliases
+        if sys.version_info < (3, 2):
+            cls.assertRegex = cls.assertRegexpMatches
+            cls.assertRaisesRegex = cls.assertRaisesRegexp
+
         cls.wd = build_temp_workspace({
             # .yaml file at root
             'a.yaml': '---\n'

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -48,7 +48,7 @@ class SimpleConfigTestCase(unittest.TestCase):
             config.YamlLintConfig('not: valid: yaml')
 
     def test_unknown_rule(self):
-        with self.assertRaisesRegexp(
+        with self.assertRaisesRegex(
                 config.YamlLintConfigError,
                 'invalid config: no such rule: "this-one-does-not-exist"'):
             config.YamlLintConfig('rules:\n'
@@ -67,7 +67,7 @@ class SimpleConfigTestCase(unittest.TestCase):
         self.assertEqual(c.rules['colons']['max-spaces-after'], 1)
 
     def test_unknown_option(self):
-        with self.assertRaisesRegexp(
+        with self.assertRaisesRegex(
                 config.YamlLintConfigError,
                 'invalid config: unknown option "abcdef" for rule "colons"'):
             config.YamlLintConfig('rules:\n'
@@ -105,7 +105,7 @@ class SimpleConfigTestCase(unittest.TestCase):
         self.assertEqual(c.rules['indentation']['check-multi-line-strings'],
                          False)
 
-        with self.assertRaisesRegexp(
+        with self.assertRaisesRegex(
                 config.YamlLintConfigError,
                 'invalid config: option "indent-sequences" of "indentation" '
                 'should be in '):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -31,6 +31,15 @@ from yamllint import config
 
 
 class SimpleConfigTestCase(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        super(SimpleConfigTestCase, cls).setUpClass()
+
+        # https://docs.python.org/3/library/unittest.html#deprecated-aliases
+        if sys.version_info < (3, 2):
+            cls.assertRegex = cls.assertRegexpMatches
+            cls.assertRaisesRegex = cls.assertRaisesRegexp
+
     def test_parse_config(self):
         new = config.YamlLintConfig('rules:\n'
                                     '  colons:\n'

--- a/tests/test_module.py
+++ b/tests/test_module.py
@@ -26,6 +26,15 @@ PYTHON = sys.executable or 'python'
 
 
 class ModuleTestCase(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        super(ModuleTestCase, cls).setUpClass()
+
+        # https://docs.python.org/3/library/unittest.html#deprecated-aliases
+        if sys.version_info < (3, 2):
+            cls.assertRegex = cls.assertRegexpMatches
+            cls.assertRaisesRegex = cls.assertRaisesRegexp
+
     def setUp(self):
         self.wd = tempfile.mkdtemp(prefix='yamllint-tests-')
 

--- a/tests/test_module.py
+++ b/tests/test_module.py
@@ -47,8 +47,7 @@ class ModuleTestCase(unittest.TestCase):
             subprocess.check_output([PYTHON, '-m', 'yamllint'],
                                     stderr=subprocess.STDOUT)
         self.assertEqual(ctx.exception.returncode, 2)
-        self.assertRegex(ctx.exception.output.decode(),
-                                 r'^usage: yamllint')
+        self.assertRegex(ctx.exception.output.decode(), r'^usage: yamllint')
 
     def test_run_module_on_bad_dir(self):
         with self.assertRaises(subprocess.CalledProcessError) as ctx:
@@ -56,7 +55,7 @@ class ModuleTestCase(unittest.TestCase):
                                      '/does/not/exist'],
                                     stderr=subprocess.STDOUT)
         self.assertRegex(ctx.exception.output.decode(),
-                                 r'No such file or directory')
+                         r'No such file or directory')
 
     def test_run_module_on_file(self):
         out = subprocess.check_output(

--- a/tests/test_module.py
+++ b/tests/test_module.py
@@ -47,7 +47,7 @@ class ModuleTestCase(unittest.TestCase):
             subprocess.check_output([PYTHON, '-m', 'yamllint'],
                                     stderr=subprocess.STDOUT)
         self.assertEqual(ctx.exception.returncode, 2)
-        self.assertRegexpMatches(ctx.exception.output.decode(),
+        self.assertRegex(ctx.exception.output.decode(),
                                  r'^usage: yamllint')
 
     def test_run_module_on_bad_dir(self):
@@ -55,7 +55,7 @@ class ModuleTestCase(unittest.TestCase):
             subprocess.check_output([PYTHON, '-m', 'yamllint',
                                      '/does/not/exist'],
                                     stderr=subprocess.STDOUT)
-        self.assertRegexpMatches(ctx.exception.output.decode(),
+        self.assertRegex(ctx.exception.output.decode(),
                                  r'No such file or directory')
 
     def test_run_module_on_file(self):


### PR DESCRIPTION
Rebasing of PR #330. This replaces the `unittest` deprecated aliases to avoid warnings when running the tests.

For more info: https://docs.python.org/3/library/unittest.html#deprecated-aliases