### PR TITLE
Add support for Python 3.9, drop Python 3.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ python:
   - 3.6
   - 3.7
   - 3.8
+  - 3.9
   - nightly
 env:
   - REMOVE_LOCALES=false

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,11 +29,11 @@ classifiers =
   Programming Language :: Python :: 2
   Programming Language :: Python :: 2.7
   Programming Language :: Python :: 3
-  Programming Language :: Python :: 3.4
   Programming Language :: Python :: 3.5
   Programming Language :: Python :: 3.6
   Programming Language :: Python :: 3.7
   Programming Language :: Python :: 3.8
+  Programming Language :: Python :: 3.9
   Topic :: Software Development
   Topic :: Software Development :: Debuggers
   Topic :: Software Development :: Quality Assurance
@@ -48,7 +48,7 @@ project_urls =
 [options]
 packages = find:
 
-python_requires = >=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*
+python_requires = >=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*
 
 include_package_data = True
 install_requires =


### PR DESCRIPTION
Add support for Python 3.9 since it was officially released in October and drop support for Python 3.4 since it is end-of-life (EOL).

Also, tried testing yamllint on Python 3.4 and it seems `pyyaml` has dropped support for Python 3.4, so another good reason to drop:

```
❯ sudo /usr/local/bin/python3.4 -m pip install pyyaml                                                                                                      (base)
DEPRECATION: Python 3.4 support has been deprecated. pip 19.1 will be the last one supporting it. Please upgrade your Python as Python 3.4 won't be maintained after March 2019 (cf PEP 429).
Collecting pyyaml
  Downloading https://files.pythonhosted.org/packages/64/c2/b80047c7ac2478f9501676c988a5411ed5572f35d1beff9cae07d321512c/PyYAML-5.3.1.tar.gz (269kB)
     |████████████████████████████████| 276kB 1.1MB/s
ERROR: PyYAML requires Python '>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*' but the running Python is 3.4.10
```