### PR TITLE
Allow only non-empty brackets/braces

### DIFF
--- a/tests/rules/test_braces.py
+++ b/tests/rules/test_braces.py
@@ -69,6 +69,14 @@ class ColonTestCase(RuleTestCase):
         self.check('---\n'
                    'dict: {}\n', conf)
         self.check('---\n'
+                   'dict: {\n'
+                   '}\n', conf)
+        self.check('---\n'
+                   'dict: {\n'
+                   '# commented: value\n'
+                   '# another: value2\n'
+                   '}\n', conf)
+        self.check('---\n'
                    'dict: {a}\n', conf, problem=(2, 8))
         self.check('---\n'
                    'dict: {a: 1}\n', conf, problem=(2, 8))

--- a/tests/rules/test_braces.py
+++ b/tests/rules/test_braces.py
@@ -61,6 +61,22 @@ class ColonTestCase(RuleTestCase):
                    '  a: 1\n'
                    '}\n', conf, problem=(2, 8))
 
+        conf = ('braces:\n'
+                '  forbid: non-empty\n')
+        self.check('---\n'
+                   'dict:\n'
+                   '  a: 1\n', conf)
+        self.check('---\n'
+                   'dict: {}\n', conf)
+        self.check('---\n'
+                   'dict: {a}\n', conf, problem=(2, 8))
+        self.check('---\n'
+                   'dict: {a: 1}\n', conf, problem=(2, 8))
+        self.check('---\n'
+                   'dict: {\n'
+                   '  a: 1\n'
+                   '}\n', conf, problem=(2, 8))
+
     def test_min_spaces(self):
         conf = ('braces:\n'
                 '  max-spaces-inside: -1\n'

--- a/tests/rules/test_brackets.py
+++ b/tests/rules/test_brackets.py
@@ -69,6 +69,13 @@ class ColonTestCase(RuleTestCase):
         self.check('---\n'
                    'array: []\n', conf)
         self.check('---\n'
+                   'array: [\n\n'
+                   ']\n', conf)
+        self.check('---\n'
+                   'array: [\n'
+                   '# a comment\n'
+                   ']\n', conf)
+        self.check('---\n'
                    'array: [a, b]\n', conf, problem=(2, 9))
         self.check('---\n'
                    'array: [\n'

--- a/tests/rules/test_brackets.py
+++ b/tests/rules/test_brackets.py
@@ -60,6 +60,22 @@ class ColonTestCase(RuleTestCase):
                    '  b\n'
                    ']\n', conf, problem=(2, 9))
 
+        conf = ('brackets:\n'
+                '  forbid: non-empty\n')
+        self.check('---\n'
+                   'array:\n'
+                   '  - a\n'
+                   '  - b\n', conf)
+        self.check('---\n'
+                   'array: []\n', conf)
+        self.check('---\n'
+                   'array: [a, b]\n', conf, problem=(2, 9))
+        self.check('---\n'
+                   'array: [\n'
+                   '  a,\n'
+                   '  b\n'
+                   ']\n', conf, problem=(2, 9))
+
     def test_min_spaces(self):
         conf = ('brackets:\n'
                 '  max-spaces-inside: -1\n'

--- a/yamllint/rules/braces.py
+++ b/yamllint/rules/braces.py
@@ -154,14 +154,15 @@ DEFAULT = {'forbid': False,
 
 
 def check(conf, token, prev, next, nextnext, context):
-    if conf['forbid'] == True and isinstance(token, yaml.FlowMappingStartToken):
+    if (conf['forbid'] is True and
+            isinstance(token, yaml.FlowMappingStartToken)):
         yield LintProblem(token.start_mark.line + 1,
                           token.end_mark.column + 1,
                           'forbidden flow mapping')
 
     elif (conf['forbid'] == 'non-empty' and
-      isinstance(token, yaml.FlowMappingStartToken) and
-      not isinstance(next, yaml.FlowMappingEndToken)):
+            isinstance(token, yaml.FlowMappingStartToken) and
+            not isinstance(next, yaml.FlowMappingEndToken)):
         yield LintProblem(token.start_mark.line + 1,
                           token.end_mark.column + 1,
                           'forbidden flow mapping')

--- a/yamllint/rules/brackets.py
+++ b/yamllint/rules/brackets.py
@@ -155,14 +155,15 @@ DEFAULT = {'forbid': False,
 
 
 def check(conf, token, prev, next, nextnext, context):
-    if conf['forbid'] == True and isinstance(token, yaml.FlowSequenceStartToken):
+    if (conf['forbid'] is True and
+            isinstance(token, yaml.FlowSequenceStartToken)):
         yield LintProblem(token.start_mark.line + 1,
                           token.end_mark.column + 1,
                           'forbidden flow sequence')
 
     elif (conf['forbid'] == 'non-empty' and
-      isinstance(token, yaml.FlowSequenceStartToken) and
-      not isinstance(next, yaml.FlowSequenceEndToken)):
+            isinstance(token, yaml.FlowSequenceStartToken) and
+            not isinstance(next, yaml.FlowSequenceEndToken)):
         yield LintProblem(token.start_mark.line + 1,
                           token.end_mark.column + 1,
                           'forbidden flow sequence')


### PR DESCRIPTION
We'd like to disallow brackets and braces in our YAML, but there's a
catch: the only way to describe an empty array or hash in YAML is to
supply an empty one (`[]` or `{}`). Otherwise, the value will be null.

This commit adds a `non-empty` option to `forbid` for brackets and
braces. When it is set, all flow and sequence mappings will cause errors
_except_ for empty ones.