### PR TITLE
End support for Python 2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@
 dist: xenial  # required for Python >= 3.7 (travis-ci/travis-ci#9069)
 language: python
 python:
-  - 2.7
   - 3.5
   - 3.6
   - 3.7
@@ -13,17 +12,14 @@ env:
   - REMOVE_LOCALES=false
   - REMOVE_LOCALES=true
 install:
-  - pip install pyyaml coveralls flake8 flake8-import-order doc8
-  - if [[ $TRAVIS_PYTHON_VERSION != 2* ]]; then pip install sphinx; fi
+  - pip install pyyaml coveralls flake8 flake8-import-order doc8 sphinx
   - pip install .
   - if [[ $REMOVE_LOCALES = "true" ]]; then sudo rm -rf /usr/lib/locale/*; fi
 script:
   - if [[ $TRAVIS_PYTHON_VERSION != nightly ]]; then flake8 .; fi
-  - if [[ $TRAVIS_PYTHON_VERSION != 2* ]]; then doc8 $(git ls-files '*.rst'); fi
+  - doc8 $(git ls-files '*.rst')
   - yamllint --strict $(git ls-files '*.yaml' '*.yml')
   - coverage run --source=yamllint -m unittest discover
-  - if [[ $TRAVIS_PYTHON_VERSION != 2* ]]; then
-      python setup.py build_sphinx;
-    fi
+  - python setup.py build_sphinx
 after_success:
   coveralls

--- a/README.rst
+++ b/README.rst
@@ -19,11 +19,7 @@ indentation, etc.
    :target: https://yamllint.readthedocs.io/en/latest/?badge=latest
    :alt: Documentation status
 
-Written in Python (compatible with Python 2 & 3).
-
-⚠ Python 2 upstream support stopped on January 1, 2020. yamllint will keep
-best-effort support for Python 2.7 until January 1, 2021. Past that date,
-yamllint will drop all Python 2-related code.
+Written in Python (compatible with Python 3 only).
 
 Documentation
 -------------

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,8 +26,6 @@ classifiers =
   Environment :: Console
   Intended Audience :: Developers
   License :: OSI Approved :: GNU General Public License v3 (GPLv3)
-  Programming Language :: Python :: 2
-  Programming Language :: Python :: 2.7
   Programming Language :: Python :: 3
   Programming Language :: Python :: 3.5
   Programming Language :: Python :: 3.6
@@ -48,7 +46,7 @@ project_urls =
 [options]
 packages = find:
 
-python_requires = >=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*
+python_requires = >=3.5.*
 
 include_package_data = True
 install_requires =

--- a/tests/rules/test_line_length.py
+++ b/tests/rules/test_line_length.py
@@ -14,9 +14,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import sys
-import unittest
-
 from tests.common import RuleTestCase
 
 
@@ -159,7 +156,6 @@ class LineLengthTestCase(RuleTestCase):
                    '  {% this line is' + 99 * ' really' + ' long %}\n',
                    conf, problem=(3, 81))
 
-    @unittest.skipIf(sys.version_info < (3, 0), 'Python 2 not supported')
     def test_unicode(self):
         conf = 'line-length: {max: 53}'
         self.check('---\n'

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -14,10 +14,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-try:
-    from cStringIO import StringIO
-except ImportError:
-    from io import StringIO
+from io import StringIO
 import fcntl
 import locale
 import os
@@ -70,11 +67,6 @@ class CommandLineTestCase(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         super(CommandLineTestCase, cls).setUpClass()
-
-        # https://docs.python.org/3/library/unittest.html#deprecated-aliases
-        if sys.version_info < (3, 2):
-            cls.assertRegex = cls.assertRegexpMatches
-            cls.assertRaisesRegex = cls.assertRaisesRegexp
 
         cls.wd = build_temp_workspace({
             # .yaml file at root

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -14,10 +14,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-try:
-    from cStringIO import StringIO
-except ImportError:
-    from io import StringIO
+from io import StringIO
 import os
 import shutil
 import sys
@@ -31,15 +28,6 @@ from yamllint import config
 
 
 class SimpleConfigTestCase(unittest.TestCase):
-    @classmethod
-    def setUpClass(cls):
-        super(SimpleConfigTestCase, cls).setUpClass()
-
-        # https://docs.python.org/3/library/unittest.html#deprecated-aliases
-        if sys.version_info < (3, 2):
-            cls.assertRegex = cls.assertRegexpMatches
-            cls.assertRaisesRegex = cls.assertRaisesRegexp
-
     def test_parse_config(self):
         new = config.YamlLintConfig('rules:\n'
                                     '  colons:\n'

--- a/tests/test_module.py
+++ b/tests/test_module.py
@@ -26,15 +26,6 @@ PYTHON = sys.executable or 'python'
 
 
 class ModuleTestCase(unittest.TestCase):
-    @classmethod
-    def setUpClass(cls):
-        super(ModuleTestCase, cls).setUpClass()
-
-        # https://docs.python.org/3/library/unittest.html#deprecated-aliases
-        if sys.version_info < (3, 2):
-            cls.assertRegex = cls.assertRegexpMatches
-            cls.assertRaisesRegex = cls.assertRaisesRegexp
-
     def setUp(self):
         self.wd = tempfile.mkdtemp(prefix='yamllint-tests-')
 

--- a/yamllint/linter.py
+++ b/yamllint/linter.py
@@ -233,7 +233,7 @@ def run(input, conf, filepath=None):
     if conf.is_file_ignored(filepath):
         return ()
 
-    if isinstance(input, (type(b''), type(u''))):  # compat with Python 2 & 3
+    if isinstance(input, (bytes, str)):
         return _run(input, conf, filepath)
     elif hasattr(input, 'read'):  # Python 2's file or Python 3's io.IOBase
         # We need to have everything in memory to parse correctly

--- a/yamllint/rules/line_length.py
+++ b/yamllint/rules/line_length.py
@@ -17,10 +17,6 @@
 """
 Use this rule to set a limit to lines length.
 
-Note: with Python 2, the ``line-length`` rule may not work properly with
-unicode characters because of the way strings are represented in bytes. We
-recommend running yamllint with Python 3.
-
 .. rubric:: Options
 
 * ``max`` defines the maximal (inclusive) length of lines.


### PR DESCRIPTION
As planned and advertized, yamllint drops support for Python 2 on 2021.