### PR TITLE
setuptools is a runtime dep only for Python < 3.8

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -52,7 +52,7 @@ include_package_data = True
 install_requires =
   pathspec >= 0.5.3
   pyyaml
-  setuptools
+  setuptools; python_version < "3.8"
 
 test_suite = tests
 


### PR DESCRIPTION
> In recent versions of setuptools and Python, console-script entry
points are using stdlib importlib by default, thus setuptools is no
longer a runtime dependency.

pypa/setuptools#2197
https://github.com/pypa/setuptools/blob/main/CHANGES.rst#v4730
https://docs.python.org/3/library/importlib.metadata.html