### PR TITLE
line_length: skip all hash signs starting comment

### DIFF
--- a/tests/rules/test_line_length.py
+++ b/tests/rules/test_line_length.py
@@ -120,11 +120,22 @@ class LineLengthTestCase(RuleTestCase):
         self.check('---\n'
                    '# http://www.verylongurlurlurlurlurlurlurlurl.com\n'
                    'key:\n'
-                   '  value:\n', conf)
+                   '  subkey: value\n', conf)
         self.check('---\n'
                    '## http://www.verylongurlurlurlurlurlurlurlurl.com\n'
                    'key:\n'
-                   '  value:\n', conf)
+                   '  subkey: value\n', conf)
+        self.check('---\n'
+                   '# # http://www.verylongurlurlurlurlurlurlurlurl.com\n'
+                   'key:\n'
+                   '  subkey: value\n', conf,
+                   problem=(2, 21))
+        self.check('---\n'
+                   '#A http://www.verylongurlurlurlurlurlurlurlurl.com\n'
+                   'key:\n'
+                   '  subkey: value\n', conf,
+                   problem1=(2, 2, 'comments'),
+                   problem2=(2, 21, 'line-length'))
 
         conf = ('line-length: {max: 20, allow-non-breakable-words: true}\n'
                 'trailing-spaces: disable')

--- a/tests/rules/test_line_length.py
+++ b/tests/rules/test_line_length.py
@@ -116,6 +116,16 @@ class LineLengthTestCase(RuleTestCase):
                    'long_line: http://localhost/very/very/long/url\n'
                    '...\n', conf, problem=(2, 21))
 
+        conf = 'line-length: {max: 20, allow-non-breakable-words: true}'
+        self.check('---\n'
+                   '# http://www.verylongurlurlurlurlurlurlurlurl.com\n'
+                   'key:\n'
+                   '  value:\n', conf)
+        self.check('---\n'
+                   '## http://www.verylongurlurlurlurlurlurlurlurl.com\n'
+                   'key:\n'
+                   '  value:\n', conf)
+
         conf = ('line-length: {max: 20, allow-non-breakable-words: true}\n'
                 'trailing-spaces: disable')
         self.check('---\n'

--- a/yamllint/rules/line_length.py
+++ b/yamllint/rules/line_length.py
@@ -140,11 +140,11 @@ def check(conf, line):
                 start += 1
 
             if start != line.end:
-                if line.buffer[start] in ('#'):
-                    idx = line.buffer.find(' ', start, line.end)
-                    if idx != -1:
-                        start = idx + 1
-                elif line.buffer[start] in ('-'):
+                if line.buffer[start] == '#':
+                    while line.buffer[start] == '#':
+                        start += 1
+                    start += 1
+                elif line.buffer[start] == '-':
                     start += 2
 
                 if line.buffer.find(' ', start, line.end) == -1:

--- a/yamllint/rules/line_length.py
+++ b/yamllint/rules/line_length.py
@@ -140,7 +140,11 @@ def check(conf, line):
                 start += 1
 
             if start != line.end:
-                if line.buffer[start] in ('#', '-'):
+                if line.buffer[start] in ('#'):
+                    idx = line.buffer.find(' ', start, line.end)
+                    if idx != -1:
+                        start = idx + 1
+                elif line.buffer[start] in ('-'):
                     start += 2
 
                 if line.buffer.find(' ', start, line.end) == -1:


### PR DESCRIPTION
Whenever a comment start with more than 1 `#` then using the following config

```yaml
rules:
  line-length:
    max: 20
    allow-non-breakable-words: true
```

to lint the following document:

```yaml
## http://www.verylongurlurlurlurlurlurlurlurl.com
key:
  subkey: "value"
```

will disregard the `max` property and issue an error/warning anyway.

This PR addresses that by jumping not 2 but `length_of_hash_signs_at_line_begining + 1`