### PR TITLE
CI: Fix failing 'coverage' command because of $PATH

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -45,6 +45,8 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.pyver }}
+      - name: Fix GitHub Actions path
+        run: echo /home/runner/.local/bin >>$GITHUB_PATH
       - run: python -m pip install coveralls
       - run: python -m pip install .
       - run: coverage run --source=yamllint -m unittest discover

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -47,8 +47,8 @@ jobs:
           python-version: ${{ matrix.pyver }}
       - name: Fix GitHub Actions path
         run: echo /home/runner/.local/bin >>$GITHUB_PATH
-      - run: python -m pip install coveralls
-      - run: python -m pip install .
+      - run: pip install coveralls
+      - run: pip install .
       - run: coverage run --source=yamllint -m unittest discover
       - name: Coveralls
         uses: AndreMiras/coveralls-python-action@develop


### PR DESCRIPTION
#### CI: Fix failing 'coverage' command because of $PATH

Very probably due to:
https://github.com/actions/virtual-environments/issues/2455#issuecomment-787511010

---

#### CI: Simplify 'pip' commands
