### PR TITLE
Use cleaned file path in logged output

### DIFF
--- a/yamllint/cli.py
+++ b/yamllint/cli.py
@@ -207,7 +207,7 @@ def run(argv=None):
         except EnvironmentError as e:
             print(e, file=sys.stderr)
             sys.exit(-1)
-        prob_level = show_problems(problems, file, args_format=args.format,
+        prob_level = show_problems(problems, filepath, args_format=args.format,
                                    no_warn=args.no_warnings)
         max_level = max(max_level, prob_level)
 


### PR DESCRIPTION
Fixes #377 

Shown file's path should use the cleaned version, without the leading `./`.
Otherwise it confuses Github which cannot fin the file on which to put the annotation.

Every method using the parameter are actually expecting a string. The file pointer, when casted to string was yielding an actual filename, but with the leading `./`.