### PR TITLE
Declare build system dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[build-system]
+requires = ["setuptools", "wheel"]


### PR DESCRIPTION
Fixes #380

https://packaging.python.org/specifications/declaring-build-dependencies/
https://github.com/pypa/pip/issues/2381