### PR TITLE
setup: update python_requires to comply with PEP 345/440

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -46,7 +46,7 @@ project_urls =
 [options]
 packages = find:
 
-python_requires = >=3.5.*
+python_requires = >=3.5
 
 include_package_data = True
 install_requires =


### PR DESCRIPTION
According to [PEP 345 Requires-Python](https://www.python.org/dev/peps/pep-0345/#requires-python), the value of this field must be a valid [Version Specifier](https://www.python.org/dev/peps/pep-0345/#version-specifiers). Which in turn expects this to comply with [PEP 440](https://www.python.org/dev/peps/pep-0440/).

While not an issue for those that directly use `pip`, this will cause issues for `poetry` users in the next release (if their current stance is maintained). Discussion of the issue and there stance can be found here: https://github.com/python-poetry/poetry/issues/4095.

resolves #387 