### PR TITLE
Restore setuptools requirement for Python < 3.8

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -52,7 +52,7 @@ include_package_data = True
 install_requires =
   pathspec >= 0.5.3
   pyyaml
-  setuptools; python_version < "3.8"
+  setuptools
 
 test_suite = tests
 


### PR DESCRIPTION
This reverts commit 8f68248 "Remove runtime dep 'setuptools' for Python
< 3.8". It looks like removing setuptools induces problems on some
systems, see for example the linked discussion.

Fixes https://github.com/adrienverge/yamllint/issues/380.