### PR TITLE
Add support for Python 3.10, drop Python 3.5

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,8 +17,6 @@ jobs:
         uses: actions/checkout@v2
       - name: Set up Python
         uses: actions/setup-python@v2
-        with:
-          python-version: 3.9
       - run: python -m pip install flake8 flake8-import-order doc8 sphinx
       - run: python -m pip install .
       - run: flake8 .
@@ -30,23 +28,23 @@ jobs:
     name: Tests
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         python-version:
-          - 3.6
-          - 3.7
-          - 3.8
-          - 3.9
-          - 3.10
-          - nightly
+          - '3.6'
+          - '3.7'
+          - '3.8'
+          - '3.9'
+          - '3.10'
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Set up Python ${{ matrix.pyver }}
+      - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v2
         with:
-          python-version: ${{ matrix.pyver }}
-      - name: Fix GitHub Actions path
-        run: echo /home/runner/.local/bin >>$GITHUB_PATH
+          python-version: ${{ matrix.python-version }}
+      - name: Append GitHub Actions system path
+        run: echo "$HOME/.local/bin" >> $GITHUB_PATH
       - run: pip install coveralls
       - run: pip install .
       - run: coverage run --source=yamllint -m unittest discover

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,11 +32,11 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - 3.5
           - 3.6
           - 3.7
           - 3.8
           - 3.9
+          - 3.10
           - nightly
     steps:
       - name: Checkout

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,11 +27,11 @@ classifiers =
   Intended Audience :: Developers
   License :: OSI Approved :: GNU General Public License v3 (GPLv3)
   Programming Language :: Python :: 3
-  Programming Language :: Python :: 3.5
   Programming Language :: Python :: 3.6
   Programming Language :: Python :: 3.7
   Programming Language :: Python :: 3.8
   Programming Language :: Python :: 3.9
+  Programming Language :: Python :: 3.10
   Topic :: Software Development
   Topic :: Software Development :: Debuggers
   Topic :: Software Development :: Quality Assurance
@@ -46,7 +46,7 @@ project_urls =
 [options]
 packages = find:
 
-python_requires = >=3.5
+python_requires = >=3.6
 
 include_package_data = True
 install_requires =


### PR DESCRIPTION
- Add support for Python 3.10 released on 2021-10-04
- Drop support for Python 3.5 since it has reached end-of-life
- Fix github actions workflow:
  - install correct Python version
  - run tests after linting
  - add ~/.local/bin to system path for both jobs