### PR TITLE
Update github formatting output to utilize groups

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -553,11 +553,13 @@ class CommandLineTestCase(unittest.TestCase):
         with RunContext(self) as ctx:
             cli.run((path, '--format', 'github'))
         expected_out = (
-            '::error file=%s,line=2,col=4::[trailing-spaces] trailing'
+            '::group::%s\n'
+            '::error file=%s,line=2,col=4::2:4 [trailing-spaces] trailing'
             ' spaces\n'
-            '::error file=%s,line=3,col=4::[new-line-at-end-of-file] no'
+            '::error file=%s,line=3,col=4::3:4 [new-line-at-end-of-file] no'
             ' new line character at the end of file\n'
-            % (path, path))
+            '::endgroup::\n\n'
+            % (path, path, path))
         self.assertEqual(
             (ctx.returncode, ctx.stdout, ctx.stderr), (1, expected_out, ''))
 
@@ -571,11 +573,13 @@ class CommandLineTestCase(unittest.TestCase):
             os.environ['GITHUB_WORKFLOW'] = 'something'
             cli.run((path, ))
         expected_out = (
-            '::error file=%s,line=2,col=4::[trailing-spaces] trailing'
+            '::group::%s\n'
+            '::error file=%s,line=2,col=4::2:4 [trailing-spaces] trailing'
             ' spaces\n'
-            '::error file=%s,line=3,col=4::[new-line-at-end-of-file] no'
+            '::error file=%s,line=3,col=4::3:4 [new-line-at-end-of-file] no'
             ' new line character at the end of file\n'
-            % (path, path))
+            '::endgroup::\n\n'
+            % (path, path, path))
         self.assertEqual(
             (ctx.returncode, ctx.stdout, ctx.stderr), (1, expected_out, ''))
 

--- a/yamllint/cli.py
+++ b/yamllint/cli.py
@@ -93,6 +93,10 @@ class Format(object):
         line += 'line=' + format(problem.line) + ','
         line += 'col=' + format(problem.column)
         line += '::'
+        line += format(problem.line)
+        line += ':'
+        line += format(problem.column)
+        line += ' '
         if problem.rule:
             line += '[' + problem.rule + '] '
         line += problem.desc
@@ -117,6 +121,9 @@ def show_problems(problems, file, args_format, no_warn):
         if args_format == 'parsable':
             print(Format.parsable(problem, file))
         elif args_format == 'github':
+            if first:
+                print('::group::%s' % file)
+                first = False
             print(Format.github(problem, file))
         elif args_format == 'colored':
             if first:
@@ -128,6 +135,9 @@ def show_problems(problems, file, args_format, no_warn):
                 print(file)
                 first = False
             print(Format.standard(problem, file))
+
+    if not first and args_format == 'github':
+        print('::endgroup::')
 
     if not first and args_format != 'parsable':
         print('')


### PR DESCRIPTION
Resolves #421

Update the github formatting to utilize groups in the output and provide the line/column number for the error in the output log.