### PR TITLE
fix: allow whitespace after the shebang marker. Closes #428.

### DIFF
--- a/tests/rules/test_comments.py
+++ b/tests/rules/test_comments.py
@@ -97,7 +97,7 @@ class CommentsTestCase(RuleTestCase):
                    '#!/bin/env my-interpreter\n'
                    '', conf,
                    problem1=(1, 2), problem2=(3, 2), problem3=(4, 2))
-        self.check('#! not a shebang\n',
+        self.check('#! is a valid shebang too\n',
                    conf, problem1=(1, 2))
         self.check('key:  #!/not/a/shebang\n',
                    conf, problem1=(1, 8))
@@ -117,8 +117,7 @@ class CommentsTestCase(RuleTestCase):
                    '#comment\n'
                    '#!/bin/env my-interpreter\n', conf,
                    problem2=(3, 2), problem3=(4, 2))
-        self.check('#! not a shebang\n',
-                   conf, problem1=(1, 2))
+        self.check('#! is a valid shebang too\n', conf)
         self.check('key:  #!/not/a/shebang\n',
                    conf, problem1=(1, 8))
 

--- a/yamllint/rules/comments.py
+++ b/yamllint/rules/comments.py
@@ -74,8 +74,6 @@ Use this rule to control the position and formatting of comments.
 """
 
 
-import re
-
 from yamllint.linter import LintProblem
 
 

--- a/yamllint/rules/comments.py
+++ b/yamllint/rules/comments.py
@@ -105,7 +105,7 @@ def check(conf, comment):
             if (conf['ignore-shebangs'] and
                     comment.line_no == 1 and
                     comment.column_no == 1 and
-                    re.match(r'^!\S', comment.buffer[text_start:])):
+                    comment.buffer[text_start:].startswith('!')):
                 return
             # We can test for both \r and \r\n just by checking first char
             # \r itself is a valid newline on some older OS.

--- a/yamllint/rules/comments.py
+++ b/yamllint/rules/comments.py
@@ -103,7 +103,7 @@ def check(conf, comment):
             if (conf['ignore-shebangs'] and
                     comment.line_no == 1 and
                     comment.column_no == 1 and
-                    comment.buffer[text_start:].startswith('!')):
+                    comment.buffer[text_start] == '!'):
                 return
             # We can test for both \r and \r\n just by checking first char
             # \r itself is a valid newline on some older OS.


### PR DESCRIPTION
Basically, any character is now allowed after the shebang marker.