### PR TITLE
Correct link syntax on integration.rst

### DIFF
--- a/docs/integration.rst
+++ b/docs/integration.rst
@@ -22,7 +22,7 @@ Integration with GitHub Actions
 -------------------------------
 
 yamllint auto-detects when it's running inside of `GitHub
-Actions<https://github.com/features/actions>` and automatically uses the suited
+Actions <https://github.com/features/actions>`_ and automatically uses the suited
 output format to decorate code with linting errors automatically. You can also
 force the GitHub Actions output with ``yamllint --format github``.
 


### PR DESCRIPTION
This PR corrects the link syntax for a reference on integration.rst.