### PR TITLE
Add rule to forbid empty values

### DIFF
--- a/tests/rules/test_empty_values.py
+++ b/tests/rules/test_empty_values.py
@@ -62,6 +62,30 @@ class EmptyValuesTestCase(RuleTestCase):
                    'implicitly-null:with-colons:in-key2:\n', conf,
                    problem1=(2, 37))
 
+    def test_forbid_key_without_values_eof(self):
+        conf = ('empty-values: {forbid-in-block-mappings: false,\n'
+                '               forbid-in-flow-mappings: false,\n'
+                '               forbid-key-without-values-eof: true}\n')
+        self.check('---\n'
+                   'implicitly-null\n', conf, problem1=(2, 16))
+        self.check('---\n'
+                   'implicitly-null:\n', conf)
+        self.check('---\n'
+                   'explicitly-null: null\n', conf)
+        self.check('---\n'
+                   'implicitly-null:with-colons:in-key\n', conf,
+                   problem1=(2, 35))
+        self.check('---\n'
+                   'implicitly-null:with-colons:in-key:\n', conf)
+        self.check('---\n'
+                   'explicitly-null:with-colons:in-key: null\n', conf)
+        self.check('---\n'
+                   'implicitly-null:with-colons:in-key\n'
+                   'key: value\n', conf, problem1=(3, 4, 'syntax'))
+        self.check('---\n'
+                   'implicitly-null:with-colons:in-key:\n'
+                   'key: value\n', conf)
+
     def test_in_block_mappings_all_lines(self):
         conf = ('empty-values: {forbid-in-block-mappings: true,\n'
                 '               forbid-in-flow-mappings: false}\n')

--- a/yamllint/rules/empty_values.py
+++ b/yamllint/rules/empty_values.py
@@ -93,6 +93,7 @@ import yaml
 
 from yamllint.linter import LintProblem
 
+
 ID = 'empty-values'
 TYPE = 'token'
 CONF = {'forbid-in-block-mappings': bool,


### PR DESCRIPTION
Today we had an big error due to yamllint **not** considering the following yaml as invalid:
```yaml
key:value
```

That yaml can't be parsed by some yaml parsers because of the white-space missing just after the colon.

As yaml spec states:

> Normally, YAML insists the “:” mapping value indicator be [separated](https://yaml.org/spec/1.2.2/#separation-spaces) from the [value](https://yaml.org/spec/1.2.2/#nodes) by [white space](https://yaml.org/spec/1.2.2/#white-space-characters). A benefit of this restriction is that the “:” character can be used inside [plain scalars](https://yaml.org/spec/1.2.2/#plain-style), as long as it is not followed by [white space](https://yaml.org/spec/1.2.2/#white-space-characters). This allows for unquoted URLs and timestamps. It is also a potential source for confusion as “a:1” is a [plain scalar](https://yaml.org/spec/1.2.2/#plain-style) and not a [key/value pair](https://yaml.org/spec/1.2.2/#mapping).

See here for details: https://yaml.org/spec/1.2.2/#example-flow-mapping-entries

So we introduced a new option `forbid-key-without-values-eof` in the empty-values rule to forbid keys without values at the end of a file.
The default value is set to `false` to avoid to have new lint error magically appearing.
With the example yaml, we obtain the following error:
```
../test.yml
  1:10      error    key with no value found  (empty-values)
```
that option also handle

Other cases are correctly handled by the PyYaml parser.
Example with the following yaml:
```yaml
key1: value1
key2:value2
key3: value3
```
We obtain the following error (output from yamllint, even before adding the new option):
```
../test.yml
  3:1       error    syntax error: could not find expected ':' (syntax)
```