### PR TITLE
Attempt to clarify configuration file location

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -14,11 +14,11 @@ To use a custom configuration file, use the ``-c`` option:
 If ``-c`` is not provided, yamllint will look for a configuration file in the
 following locations (by order of preference):
 
-- ``.yamllint``, ``.yamllint.yaml`` or ``.yamllint.yml`` in the current working
-  directory
-- the file referenced by ``$YAMLLINT_CONFIG_FILE``, if set
-- ``$XDG_CONFIG_HOME/yamllint/config``
-- ``~/.config/yamllint/config``
+- a file named ``.yamllint``, ``.yamllint.yaml``, or ``.yamllint.yml`` in the
+  current working directory
+- a filename referenced by ``$YAMLLINT_CONFIG_FILE``, if set
+- a file named ``$XDG_CONFIG_HOME/yamllint/config`` or
+  ``~/.config/yamllint/config``, if present
 
 Finally if no config file is found, the default configuration is applied.
 


### PR DESCRIPTION
I attempted to make the docs more understandable for those who are unfamiliar with files that start with `.` or don't have a file extension in the name.

Closes #96, Closes #212