### PR TITLE
Don't break on empty stack

### DIFF
--- a/tests/rules/test_key_duplicates.py
+++ b/tests/rules/test_key_duplicates.py
@@ -87,6 +87,10 @@ class KeyDuplicatesTestCase(RuleTestCase):
                    'anchor_reference:\n'
                    '  <<: *anchor_one\n'
                    '  <<: *anchor_two\n', conf)
+        self.check('---\n'
+                   '{a:1, b:2}}\n', conf, problem=(2, 11, 'syntax'))
+        self.check('---\n'
+                   '[a, b, c]]\n', conf, problem=(2, 10, 'syntax'))
 
     def test_enabled(self):
         conf = 'key-duplicates: enable'
@@ -165,6 +169,10 @@ class KeyDuplicatesTestCase(RuleTestCase):
                    'anchor_reference:\n'
                    '  <<: *anchor_one\n'
                    '  <<: *anchor_two\n', conf)
+        self.check('---\n'
+                   '{a:1, b:2}}\n', conf, problem=(2, 11, 'syntax'))
+        self.check('---\n'
+                   '[a, b, c]]\n', conf, problem=(2, 10, 'syntax'))
 
     def test_key_tokens_in_flow_sequences(self):
         conf = 'key-duplicates: enable'

--- a/yamllint/rules/key_duplicates.py
+++ b/yamllint/rules/key_duplicates.py
@@ -84,7 +84,8 @@ def check(conf, token, prev, next, nextnext, context):
     elif isinstance(token, (yaml.BlockEndToken,
                             yaml.FlowMappingEndToken,
                             yaml.FlowSequenceEndToken)):
-        context['stack'].pop()
+        if len(context['stack']) > 0:
+            context['stack'].pop()
     elif (isinstance(token, yaml.KeyToken) and
           isinstance(next, yaml.ScalarToken)):
         # This check is done because KeyTokens can be found inside flow


### PR DESCRIPTION
If there's nothing to do when the stack is empty then this should fix issue #452 as can be seen below : 

```shell
$ git clone https://github.com/yaml/yaml-test-suite
$ cd yaml-test-suite
$ make data-update

$ yamllint data/4H7K/in.yaml
data/4H7K/in.yaml
  2:2       error    too many spaces inside brackets  (brackets)
  2:10      error    too many spaces inside brackets  (brackets)
  2:12      error    too many spaces inside brackets  (brackets)
  2:13      error    syntax error: expected '<document start>', but found ']' (syntax)

$ 
```