### PR TITLE
make rule new_lines default to dos on windows systems

### DIFF
--- a/yamllint/rules/new_lines.py
+++ b/yamllint/rules/new_lines.py
@@ -29,8 +29,17 @@ Use this rule to force the type of new line characters.
  rules:
    new-lines:
      type: unix
+
+**only** on windows (if `sys.platform == "win32"`):
+
+.. code-block:: yaml
+
+ rules:
+   new-lines:
+     type: dos
 """
 
+from sys import platform
 
 from yamllint.linter import LintProblem
 
@@ -38,7 +47,10 @@ from yamllint.linter import LintProblem
 ID = 'new-lines'
 TYPE = 'line'
 CONF = {'type': ('unix', 'dos')}
-DEFAULT = {'type': 'unix'}
+if platform == "win32":
+  DEFAULT = {'type': 'dos'}
+else:
+  DEFAULT = {'type': 'unix'}
 
 
 def check(conf, line):


### PR DESCRIPTION
As the tile sates, this PR intreduces a check for the operating system and chooses the default value for the new_line rule accordingly.

This is very usefull since this project integrates so nicely with pre-commit, but on windows git will checkout dos newlines, so the precommit can't be used since it isn't protable. This should be fixed now.

I only inteduced the actuall `win32` platform and did not use `cygwin` or `msys`, which are used on windows but intreduce a unix like enviroment with unix like tool that expect unix newlines. But this could be disscuesd 