### PR TITLE
tests: Increase test coverage

### DIFF
--- a/tests/common.py
+++ b/tests/common.py
@@ -14,7 +14,9 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import contextlib
 import os
+import shutil
 import tempfile
 import unittest
 
@@ -69,3 +71,17 @@ def build_temp_workspace(files):
                 f.write(content)
 
     return tempdir
+
+
+@contextlib.contextmanager
+def temp_workspace(files):
+    """Provide a temporary workspace that is automatically cleaned up."""
+    backup_wd = os.getcwd()
+    wd = build_temp_workspace(files)
+
+    try:
+        os.chdir(wd)
+        yield
+    finally:
+        os.chdir(backup_wd)
+        shutil.rmtree(wd)

--- a/tests/rules/test_key_ordering.py
+++ b/tests/rules/test_key_ordering.py
@@ -117,7 +117,7 @@ class KeyOrderingTestCase(RuleTestCase):
         self.addCleanup(locale.setlocale, locale.LC_ALL, (None, None))
         try:
             locale.setlocale(locale.LC_ALL, 'en_US.UTF-8')
-        except locale.Error:
+        except locale.Error:  # pragma: no cover
             self.skipTest('locale en_US.UTF-8 not available')
         conf = ('key-ordering: enable')
         self.check('---\n'
@@ -136,7 +136,7 @@ class KeyOrderingTestCase(RuleTestCase):
         self.addCleanup(locale.setlocale, locale.LC_ALL, (None, None))
         try:
             locale.setlocale(locale.LC_ALL, 'en_US.UTF-8')
-        except locale.Error:
+        except locale.Error:  # pragma: no cover
             self.skipTest('locale en_US.UTF-8 not available')
         conf = ('key-ordering: enable')
         self.check('---\n'

--- a/tests/rules/test_octal_values.py
+++ b/tests/rules/test_octal_values.py
@@ -33,6 +33,7 @@ class OctalValuesTestCase(RuleTestCase):
                 '  forbid-explicit-octal: false\n'
                 'new-line-at-end-of-file: disable\n'
                 'document-start: disable\n')
+        self.check('after-tag: !custom_tag 010', conf)
         self.check('user-city: 010', conf, problem=(1, 15))
         self.check('user-city: abc', conf)
         self.check('user-city: 010,0571', conf)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -190,6 +190,41 @@ class SimpleConfigTestCase(unittest.TestCase):
                           config.validate_rule_conf, Rule,
                           {'multiple': ['item4']})
 
+    def test_invalid_rule(self):
+        with self.assertRaisesRegex(
+                config.YamlLintConfigError,
+                'invalid config: rule "colons": should be either '
+                '"enable", "disable" or a dict'):
+            config.YamlLintConfig('rules:\n'
+                                  '  colons: invalid\n')
+
+    def test_invalid_ignore(self):
+        with self.assertRaisesRegex(
+                config.YamlLintConfigError,
+                'invalid config: ignore should contain file patterns'):
+            config.YamlLintConfig('ignore: yes\n')
+
+    def test_invalid_rule_ignore(self):
+        with self.assertRaisesRegex(
+                config.YamlLintConfigError,
+                'invalid config: ignore should contain file patterns'):
+            config.YamlLintConfig('rules:\n'
+                                  '  colons:\n'
+                                  '    ignore: yes\n')
+
+    def test_invalid_locale(self):
+        with self.assertRaisesRegex(
+                config.YamlLintConfigError,
+                'invalid config: locale should be a string'):
+            config.YamlLintConfig('locale: yes\n')
+
+    def test_invalid_yaml_files(self):
+        with self.assertRaisesRegex(
+                config.YamlLintConfigError,
+                'invalid config: yaml-files should be a list of file '
+                'patterns'):
+            config.YamlLintConfig('yaml-files: yes\n')
+
 
 class ExtendedConfigTestCase(unittest.TestCase):
     def test_extend_on_object(self):
@@ -333,6 +368,16 @@ class ExtendedConfigTestCase(unittest.TestCase):
 
         self.assertEqual(c.rules['colons']['max-spaces-before'], 0)
         self.assertEqual(c.rules['colons']['max-spaces-after'], 1)
+
+    def test_extended_ignore(self):
+        with tempfile.NamedTemporaryFile('w') as f:
+            f.write('ignore: |\n'
+                    '  *.template.yaml\n')
+            f.flush()
+            c = config.YamlLintConfig('extends: ' + f.name + '\n')
+
+        self.assertEqual(c.ignore.match_file('test.template.yaml'), True)
+        self.assertEqual(c.ignore.match_file('test.yaml'), False)
 
 
 class ExtendedLibraryConfigTestCase(unittest.TestCase):

--- a/tests/test_linter.py
+++ b/tests/test_linter.py
@@ -55,3 +55,13 @@ class LinterTestCase(unittest.TestCase):
              u'# الأَبْجَدِيَّة العَرَبِيَّة\n')
         linter.run(s, self.fake_config())
         linter.run(s.encode('utf-8'), self.fake_config())
+
+    def test_linter_problem_repr_without_rule(self):
+        problem = linter.LintProblem(1, 2, 'problem')
+
+        self.assertEqual(str(problem), '1:2: problem')
+
+    def test_linter_problem_repr_with_rule(self):
+        problem = linter.LintProblem(1, 2, 'problem', 'rule-id')
+
+        self.assertEqual(str(problem), '1:2: problem (rule-id)')


### PR DESCRIPTION
- Add a `temp_workspace` context manager to simplify writing new tests.
- Add `# pragma: no cover` to unit test code paths used for skipping tests.
  These code paths are only covered when tests are skipped.
  That makes it impractical to reach full code coverage on the unit test code.
  Having full coverage of unit tests is helpful for identifying unused tests.
- Test the `octal-values` rule with a custom tag.
- Test the cli `-d` option with the `default` config.
- Test support for the `XDG_CONFIG_HOME` env var.
- Test warning message output.
- Test support for `.yamllint.yml` config files.
- Test support for `.yamllint.yaml` config files.
- Test error handling of a rule with a non-enable|disable|dict value.
- Test error handling of `ignore` with a non-pattern value.
- Test error handling of a rule `ignore` with a non-pattern value.
- Test error handling of `locale` with a non-string value.
- Test error handling of `yaml-files` with a non-list value.
- Test extending config containing `ignore`.
- Test `LintProblem.__repr__` without a rule.
- Test `LintProblem.__repr__` with a rule.