### PR TITLE
Add rstcheck to CI to lint docs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,10 +17,13 @@ jobs:
         uses: actions/checkout@v2
       - name: Set up Python
         uses: actions/setup-python@v2
-      - run: python -m pip install flake8 flake8-import-order doc8 sphinx
+      - run:
+          python -m pip install flake8 flake8-import-order doc8 sphinx
+            rstcheck[sphinx]
       - run: python -m pip install .
       - run: flake8 .
       - run: doc8 $(git ls-files '*.rst')
+      - run: rstcheck --ignore-directives automodule $(git ls-files '*.rst')
       - run: yamllint --strict $(git ls-files '*.yaml' '*.yml')
       - run: python setup.py build_sphinx
 

--- a/README.rst
+++ b/README.rst
@@ -74,7 +74,7 @@ Usage
  # Output a parsable format (for syntax checking in editors like Vim, emacs...)
  yamllint -f parsable file.yaml
 
-`Read more in the complete documentation! <https://yamllint.readthedocs.io/>`_
+`Read more in the complete documentation! <https://yamllint.readthedocs.io/>`__
 
 Features
 ^^^^^^^^
@@ -132,7 +132,7 @@ Specific files can be ignored (totally or for some rules only) using a
        *.ignore-trailing-spaces.yaml
        /ascii-art/*
 
-`Read more in the complete documentation! <https://yamllint.readthedocs.io/>`_
+`Read more in the complete documentation! <https://yamllint.readthedocs.io/>`__
 
 License
 -------


### PR DESCRIPTION
This tool was helpful in catching style issues I made as I was writing #463. It adds approximately 2 seconds to the lint action run time.

The only complaint it had on existing documentation was petty (`Duplicate explicit target name: "read more in the complete documentation!".` - see https://github.com/sphinx-doc/sphinx/issues/3921), but I changed it anyway.