### PR TITLE
linter: Remove redundant conditional

### DIFF
--- a/yamllint/linter.py
+++ b/yamllint/linter.py
@@ -199,15 +199,11 @@ def _run(buffer, conf, filepath):
                 syntax_error.column <= problem.column):
             yield syntax_error
 
-            # If there is already a yamllint error at the same place, discard
-            # it as it is probably redundant (and maybe it's just a 'warning',
+            # Discard the problem since it is at the same place as the syntax
+            # error and is probably redundant (and maybe it's just a 'warning',
             # in which case the script won't even exit with a failure status).
-            if (syntax_error.line == problem.line and
-                    syntax_error.column == problem.column):
-                syntax_error = None
-                continue
-
             syntax_error = None
+            continue
 
         yield problem
 


### PR DESCRIPTION
Remove the redundant conditional used when reporting a syntax error at the same location as a cosmetic problem. Also reword the comment explaining the logic to more accurately describe the situation.

This eliminates an unreachable `syntax_error = None` assignment.