### PR TITLE
rule new-lines: add `type: platform` configuration option

### DIFF
--- a/tests/rules/test_new_lines.py
+++ b/tests/rules/test_new_lines.py
@@ -13,6 +13,8 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+from unittest import mock
+
 from tests.common import RuleTestCase
 
 
@@ -58,3 +60,37 @@ class NewLinesTestCase(RuleTestCase):
         self.check('\r\n', conf)
         self.check('---\ntext\n', conf, problem=(1, 4))
         self.check('---\r\ntext\r\n', conf)
+
+    def test_platform_type(self):
+        conf = ('new-line-at-end-of-file: disable\n'
+                'new-lines: {type: platform}\n')
+
+        self.check('', conf)
+
+        # mock the Linux new-line-character
+        with mock.patch('yamllint.rules.new_lines.linesep', '\n'):
+            self.check('\n', conf)
+            self.check('\r\n', conf, problem=(1, 1))
+            self.check('---\ntext\n', conf)
+            self.check('---\r\ntext\r\n', conf, problem=(1, 4))
+            self.check('---\r\ntext\n', conf, problem=(1, 4))
+            # FIXME: the following tests currently don't work
+            # because only the first line is checked for line-endings
+            # see: issue #475
+            # ---
+            # self.check('---\ntext\r\nfoo\n', conf, problem=(2, 4))
+            # self.check('---\ntext\r\n', conf, problem=(2, 4))
+
+        # mock the Windows new-line-character
+        with mock.patch('yamllint.rules.new_lines.linesep', '\r\n'):
+            self.check('\r\n', conf)
+            self.check('\n', conf, problem=(1, 1))
+            self.check('---\r\ntext\r\n', conf)
+            self.check('---\ntext\n', conf, problem=(1, 4))
+            self.check('---\ntext\r\n', conf, problem=(1, 4))
+            # FIXME: the following tests currently don't work
+            # because only the first line is checked for line-endings
+            # see: issue #475
+            # ---
+            # self.check('---\r\ntext\nfoo\r\n', conf, problem=(2, 4))
+            # self.check('---\r\ntext\n', conf, problem=(2, 4))

--- a/yamllint/rules/new_lines.py
+++ b/yamllint/rules/new_lines.py
@@ -41,13 +41,13 @@ DEFAULT = {'type': 'unix'}
 
 
 def check(conf, line):
+    if conf['type'] == 'unix':
+        newline_char = '\n'
+    elif conf['type'] == 'dos':
+        newline_char = '\r\n'
+
     if line.start == 0 and len(line.buffer) > line.end:
-        if conf['type'] == 'dos':
-            if (line.end + 2 > len(line.buffer) or
-                    line.buffer[line.end:line.end + 2] != '\r\n'):
-                yield LintProblem(1, line.end - line.start + 1,
-                                  'wrong new line character: expected \\r\\n')
-        else:
-            if line.buffer[line.end] != '\n':
-                yield LintProblem(1, line.end - line.start + 1,
-                                  'wrong new line character: expected \\n')
+        if line.buffer[line.end:line.end + len(newline_char)] != newline_char:
+            yield LintProblem(1, line.end - line.start + 1,
+                              'wrong new line character: expected {}'
+                              .format(repr(newline_char).strip('\'')))

--- a/yamllint/rules/new_lines.py
+++ b/yamllint/rules/new_lines.py
@@ -48,6 +48,6 @@ def check(conf, line):
                 yield LintProblem(1, line.end - line.start + 1,
                                   'wrong new line character: expected \\r\\n')
         else:
-            if line.buffer[line.end] == '\r':
+            if line.buffer[line.end] != '\n':
                 yield LintProblem(1, line.end - line.start + 1,
                                   'wrong new line character: expected \\n')

--- a/yamllint/rules/new_lines.py
+++ b/yamllint/rules/new_lines.py
@@ -18,8 +18,11 @@ Use this rule to force the type of new line characters.
 
 .. rubric:: Options
 
-* Set ``type`` to ``unix`` to use UNIX-typed new line characters (``\\n``), or
-  ``dos`` to use DOS-typed new line characters (``\\r\\n``).
+* Set ``type`` to ``unix`` to enforce UNIX-typed new line characters (``\\n``),
+  set ``type`` to ``dos`` to enforce DOS-typed new line characters
+  (``\\r\\n``), or set ``type`` to ``platform`` to infer the type from the
+  system running yamllint (``\\n`` on POSIX / UNIX / Linux / Mac OS systems or
+  ``\\r\\n`` on DOS / Windows systems).
 
 .. rubric:: Default values (when enabled)
 
@@ -30,19 +33,22 @@ Use this rule to force the type of new line characters.
      type: unix
 """
 
+from os import linesep
 
 from yamllint.linter import LintProblem
 
 
 ID = 'new-lines'
 TYPE = 'line'
-CONF = {'type': ('unix', 'dos')}
+CONF = {'type': ('unix', 'dos', 'platform')}
 DEFAULT = {'type': 'unix'}
 
 
 def check(conf, line):
     if conf['type'] == 'unix':
         newline_char = '\n'
+    elif conf['type'] == 'platform':
+        newline_char = linesep
     elif conf['type'] == 'dos':
         newline_char = '\r\n'
 


### PR DESCRIPTION
This PR follows up on #456 in which it was concluded that the default for the new-lines rule should not be changed but rather a new option is to be introduced.

## Problem

As explained in [this comment on the parent PR](https://github.com/adrienverge/yamllint/pull/456#issuecomment-1119438897) yamllint currently has portability issues that make it hard to use on Windows clients. These stem from git converting line-endings to the platform default on checkout and yamllint assuming that the line-ending type should be enforced for all development platforms. This leads to windows-clients needing to be heavily reconfigured to make yamllint work there properly.

## PR's content

This PR introduces a new option for the `new-lines` rule: `type: auto`.

The new option infers the correct newline character(s) from the operating system that is currently running yamllint. This allows developers to create yaml-files with their systems default settings and relying on git to convert them.

Projects that wish to enforce a certain type of line-ending are still able to do so by keeping one of the original two options.


### Linting / Testing

`flake8`, `doc8` and `unittest` completet without error on my local machine.