### PR TITLE
Remove word 'copyright', bump year

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -20,7 +20,7 @@ source_suffix = '.rst'
 master_doc = 'index'
 
 project = APP_NAME
-copyright = __copyright__
+copyright = __copyright__.lstrip('Copyright ')
 
 version = APP_VERSION
 release = APP_VERSION

--- a/yamllint/__init__.py
+++ b/yamllint/__init__.py
@@ -25,6 +25,6 @@ APP_VERSION = '1.26.3'
 APP_DESCRIPTION = __doc__
 
 __author__ = u'Adrien Vergé'
-__copyright__ = u'Copyright 2016, Adrien Vergé'
+__copyright__ = u'Copyright 2022, Adrien Vergé'
 __license__ = 'GPLv3'
 __version__ = APP_VERSION


### PR DESCRIPTION
Brought up in #476. I ran `make html man` and then inspected the copyright text and it looks good to me. Bumped the year so it shows that stuff still happens here 😁 