### PR TITLE
Automatically ignore ansible vault files

### DIFF
--- a/tests/test_linter.py
+++ b/tests/test_linter.py
@@ -55,6 +55,10 @@ class LinterTestCase(unittest.TestCase):
         linter.run(s, self.fake_config())
         linter.run(s.encode('utf-8'), self.fake_config())
 
+    def test_run_on_ansible_vault(self):
+        linter.run('$ANSIBLE_VAULT;1.1;AES256\n1643039736532396535663733313\n',
+                   self.fake_config())
+
     def test_linter_problem_repr_without_rule(self):
         problem = linter.LintProblem(1, 2, 'problem')
 

--- a/yamllint/linter.py
+++ b/yamllint/linter.py
@@ -188,6 +188,9 @@ def _run(buffer, conf, filepath):
     first_line = next(parser.line_generator(buffer)).content
     if re.match(r'^#\s*yamllint disable-file\s*$', first_line):
         return
+    elif first_line.startswith('$ANSIBLE_VAULT;'):
+        # We ignore Ansible vaults.
+        return
 
     # If the document contains a syntax error, save it and yield it at the
     # right line


### PR DESCRIPTION
Ansible vaults are YAML files which are not parsable because they are encrypted with a password.

An example Ansible vault look like this :

```
$ANSIBLE_VAULT;1.1;AES256
1643039736532396535663733313030306436333431313465653962333739613331
...
```

When launching yamllint on this file we've got : 

```shell
jerome@OPT17844:~$ yamllint --version
yamllint 1.26.3
jerome@OPT17844:~$ yamllint this-is-an-ansible-vault.yml
this-is-an-ansible-vault.yml
  1:1       warning  missing document start "---"  (document-start)

jerome@OPT17844:~$
```

Unfortunately adding the document start marker to such files would render the vault file unreadable by the `ansible-vault` command : 

```shell
jerome@OPT17844:~$ cat this-is-a-modified-ansible-vault.yml
---
$ANSIBLE_VAULT;1.1;AES256
1643039736532396535663733313030306436333431313465653962333739613331
jerome@OPT17844:~$ 

jerome@OPT17844:~$ ansible-vault view this-is-a-modified-ansible-vault.yml 
Vault password: 
ERROR! input is not vault encrypted data for this-is-a-modified-ansible-vault.yml
jerome@OPT17844:~$ 
```

So the attached commit makes yamllint ignore Ansible vault files : 

```shell
jerome@OPT17844:~$ yamllint this-is-an-ansible-vault.yml
jerome@OPT17844:~$ 
```
As an alternative, such files could be decrypted on the fly before being linted, but this would be much more complex.
