### PR TITLE
key-duplicates: Fix failing test for missing space after colon

### DIFF
--- a/tests/rules/test_key_duplicates.py
+++ b/tests/rules/test_key_duplicates.py
@@ -87,7 +87,7 @@ class KeyDuplicatesTestCase(RuleTestCase):
                    '  <<: *anchor_one\n'
                    '  <<: *anchor_two\n', conf)
         self.check('---\n'
-                   '{a:1, b:2}}\n', conf, problem=(2, 11, 'syntax'))
+                   '{a: 1, b: 2}}\n', conf, problem=(2, 13, 'syntax'))
         self.check('---\n'
                    '[a, b, c]]\n', conf, problem=(2, 10, 'syntax'))
 
@@ -169,7 +169,7 @@ class KeyDuplicatesTestCase(RuleTestCase):
                    '  <<: *anchor_one\n'
                    '  <<: *anchor_two\n', conf)
         self.check('---\n'
-                   '{a:1, b:2}}\n', conf, problem=(2, 11, 'syntax'))
+                   '{a: 1, b: 2}}\n', conf, problem=(2, 13, 'syntax'))
         self.check('---\n'
                    '[a, b, c]]\n', conf, problem=(2, 10, 'syntax'))
 


### PR DESCRIPTION
Commit c268a82 "key-duplicates: Don't crash on redundant closing
brackets or braces" fixed a problem but introduced another one: it
crashes on systems with (I guess) an old version of PyYAML. This is
probably linked to the "Allow colon in a plain scalar in a flow context"
issue on PyYAML [1].
For example, this problem happens on CentOS 8:

    FAIL: test_disabled (tests.rules.test_key_duplicates.KeyDuplicatesTestCase)
    ----------------------------------------------------------------------
    Traceback (most recent call last):
      File "…/tests/rules/test_key_duplicates.py", line 90, in test_disabled
        '{a:1, b:2}}\n', conf, problem=(2, 11, 'syntax'))
      File "…/tests/common.py", line 54, in check
        self.assertEqual(real_problems, expected_problems)
    AssertionError: Lists differ: …
    - [2:3: syntax error: found unexpected ':' (syntax)]
    + [2:11: <no description>]

I propose to simply fix the *space following a colon* problem, since
it's not related to what the original author @tamere-allo-peter tried to
fix.

\[1]: https://github.com/yaml/pyyaml/pull/45