### PR TITLE
docs: more badges from shield.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,3 +1,7 @@
+| |GitHub Badge| |PyPi version Badge| |Python version Badge|
+| |CI status Badge| |Coverage Badge| |Docs Badge|
+
+
 yamllint
 ========
 
@@ -6,18 +10,6 @@ A linter for YAML files.
 yamllint does not only check for syntax validity, but for weirdnesses like key
 repetition and cosmetic problems such as lines length, trailing spaces,
 indentation, etc.
-
-.. image::
-   https://travis-ci.org/adrienverge/yamllint.svg?branch=master
-   :target: https://travis-ci.org/adrienverge/yamllint
-   :alt: CI tests status
-.. image::
-   https://coveralls.io/repos/github/adrienverge/yamllint/badge.svg?branch=master
-   :target: https://coveralls.io/github/adrienverge/yamllint?branch=master
-   :alt: Code coverage status
-.. image:: https://readthedocs.org/projects/yamllint/badge/?version=latest
-   :target: https://yamllint.readthedocs.io/en/latest/?badge=latest
-   :alt: Documentation status
 
 Written in Python (compatible with Python 3 only).
 
@@ -138,3 +130,25 @@ License
 -------
 
 `GPL version 3 <LICENSE>`_
+
+
+
+.. |GitHub Badge| image:: https://badges.aleen42.com/src/github.svg
+   :target: https://github.com/adrienverge/yamllint
+   :alt: Github Repository
+.. |PyPi version Badge| image:: https://img.shields.io/pypi/v/yamllint
+   :target: https://pypi.org/project/yamllint/
+   :alt: PyPI package version
+.. |Python version Badge| image:: https://img.shields.io/pypi/pyversions/yamllint
+   :target: https://pypi.org/project/yamllint/
+   :alt: supported Python versions
+
+.. |CI status Badge| image:: https://travis-ci.org/adrienverge/yamllint.svg?branch=master
+   :target: https://travis-ci.org/adrienverge/yamllint
+   :alt: CI tests status
+.. |Coverage Badge| image:: https://coveralls.io/repos/github/adrienverge/yamllint/badge.svg?branch=master
+   :target: https://coveralls.io/github/adrienverge/yamllint?branch=master
+   :alt: Code coverage status
+.. |Docs Badge| image:: https://readthedocs.org/projects/yamllint/badge/?version=latest
+   :target: https://yamllint.readthedocs.io/en/latest/
+   :alt: Documentation status

--- a/README.rst
+++ b/README.rst
@@ -1,4 +1,4 @@
-| |GitHub Badge| |PyPi version Badge| |Python version Badge|
+| |GitHub Badge| |PyPi version Badge| |Python version Badge| |License Badge|
 | |CI status Badge| |Coverage Badge| |Docs Badge|
 
 
@@ -126,12 +126,6 @@ Specific files can be ignored (totally or for some rules only) using a
 
 `Read more in the complete documentation! <https://yamllint.readthedocs.io/>`__
 
-License
--------
-
-`GPL version 3 <LICENSE>`_
-
-
 
 .. |GitHub Badge| image:: https://badges.aleen42.com/src/github.svg
    :target: https://github.com/adrienverge/yamllint
@@ -142,6 +136,9 @@ License
 .. |Python version Badge| image:: https://img.shields.io/pypi/pyversions/yamllint
    :target: https://pypi.org/project/yamllint/
    :alt: supported Python versions
+.. |License Badge| image:: https://img.shields.io/pypi/l/yamllint?color=blue
+   :target: LICENSE
+   :alt: License
 
 .. |CI status Badge| image:: https://travis-ci.org/adrienverge/yamllint.svg?branch=master
    :target: https://travis-ci.org/adrienverge/yamllint


### PR DESCRIPTION
I personally find badges to be a very helpfull quick and visual way to get the most importand informations about a project. So I added some more to the project. This is the current result:

![image](https://user-images.githubusercontent.com/62838959/178148517-9f4e977e-c620-45a1-b91e-a584c3f6e06b.png)

I chose a layout that shows the generall package informations first and the existing "development" informatins on the second line.

### Discussusion:

additional Badges that I didn't find super relevant but could also be included:

![PyPI - Status](https://img.shields.io/pypi/status/yamllint)

![PyPI - Downloads](https://img.shields.io/pypi/dd/yamllint)

![PyPI - Format](https://img.shields.io/pypi/format/yamllint) ![PyPI - Wheel](https://img.shields.io/pypi/wheel/yamllint)

I wasn't sure if the LICENCE badge woulde be relevant to you or if you prefere the section at the bottom. Also should the badge fully replace the existing section or should both stay? (thats why its currently a seperate commit so I can easyer revert it)

Should the supported Python-versions bade fully replace the "_Written in Python (compatible with Python 3 only)_" line. It feels redundant to me but I didn't want to remove it. Alternativly there could also be a custom badge somewhat like this:

![custom python badge](https://img.shields.io/badge/written%20in-python3-green)

