### PR TITLE
Simplify GitHub actions example

### DIFF
--- a/docs/integration.rst
+++ b/docs/integration.rst
@@ -22,29 +22,22 @@ Integration with GitHub Actions
 -------------------------------
 
 yamllint auto-detects when it's running inside of `GitHub
-Actions <https://github.com/features/actions>`_ and automatically uses the suited
-output format to decorate code with linting errors. You can also force the
-GitHub Actions output with ``yamllint --format github``.
+Actions <https://github.com/features/actions>`_ and automatically uses the
+suited output format to decorate code with linting errors. You can also force
+the GitHub Actions output with ``yamllint --format github``.
 
-An example workflow using GitHub Actions:
+An minimal example workflow using GitHub Actions:
 
 .. code:: yaml
 
    ---
-   name: yamllint test
-
-   on: push
+   on: push  # yamllint disable-line rule:truthy
 
    jobs:
-     test:
+     lint:
        runs-on: ubuntu-latest
        steps:
-         - uses: actions/checkout@v2
-
-         - name: Set up Python
-           uses: actions/setup-python@v2
-           with:
-             python-version: 3.8
+         - uses: actions/checkout@v3
 
          - name: Install yamllint
            run: pip install yamllint

--- a/docs/text_editors.rst
+++ b/docs/text_editors.rst
@@ -9,7 +9,7 @@ text editor.
 Vim
 ---
 
-Assuming that the `ALE <https://github.com/w0rp/ale>`_ plugin is
+Assuming that the `ALE <https://github.com/dense-analysis/ale>`_ plugin is
 installed, yamllint is supported by default. It is automatically enabled when
 editing YAML files.
 


### PR DESCRIPTION
My original example had too much extra stuff that changes over time. A user can rely upon whatever version of Python `ubuntu-latest` has to be a reasonable choice that yamllint supports.