### PR TITLE
quoted-strings: add allow-quoted-quotes option

### DIFF
--- a/tests/rules/test_quoted_strings.py
+++ b/tests/rules/test_quoted_strings.py
@@ -455,33 +455,104 @@ class QuotedTestCase(RuleTestCase):
                    problem1=(9, 3), problem2=(10, 3))
 
     def test_allow_quoted_quotes(self):
-        for quote_type in ['single', 'double']:
-            for required in ['true', 'false', 'only-when-needed']:
-                for allow_quoted_quotes in ['true', 'false']:
-                    conf = ('quoted-strings: {quote-type: %s,\n'
-                            '                 required: %s,\n'
-                            '                 allow-quoted-quotes: %s}\n') % (
-                                quote_type, required, allow_quoted_quotes)
+        conf = ('quoted-strings: {quote-type: single,\n'
+                '                 required: false,\n'
+                '                 allow-quoted-quotes: false}\n')
+        self.check('---\n'
+                   'foo1: "[barbaz]"\n'          # fails
+                   'foo2: "[bar\'baz]"\n',       # fails
+                   conf, problem1=(2, 7), problem2=(3, 7))
 
-                    wrong_token_style = "'" if quote_type == 'double' else '"'
-                    right_token_style = '"' if quote_type == 'double' else "'"
+        conf = ('quoted-strings: {quote-type: single,\n'
+                '                 required: false,\n'
+                '                 allow-quoted-quotes: true}\n')
+        self.check('---\n'
+                   'foo1: "[barbaz]"\n'          # fails
+                   'foo2: "[bar\'baz]"\n',
+                   conf, problem1=(2, 7))
 
-                    # 'fooX' value is in square brackets to avoid
-                    # 'redundantly quoted' error
-                    # in 'required: only-when-needed' mode
-                    yaml_to_check = ('---\n'
-                                     # `foo1: "[barbaz]"` `foo1: '[barbaz]'`
-                                     'foo1: %(w)c[barbaz]%(w)c\n'
-                                     # `foo1: "[bar'baz]"` `foo1: '[bar"baz]'`
-                                     'foo2: %(w)c[bar%(r)cbaz]%(w)c\n'
-                                     ) % {'w': wrong_token_style,
-                                          'r': right_token_style}
+        conf = ('quoted-strings: {quote-type: single,\n'
+                '                 required: true,\n'
+                '                 allow-quoted-quotes: false}\n')
+        self.check('---\n'
+                   'foo1: "[barbaz]"\n'          # fails
+                   'foo2: "[bar\'baz]"\n',       # fails
+                   conf, problem1=(2, 7), problem2=(3, 7))
 
-                    if allow_quoted_quotes == 'false':
-                        self.check(yaml_to_check,
-                                   conf,
-                                   problem1=(2, 7),
-                                   problem2=(3, 7))
-                    else:
-                        self.check(yaml_to_check,
-                                   conf, problem1=(2, 7))
+        conf = ('quoted-strings: {quote-type: single,\n'
+                '                 required: true,\n'
+                '                 allow-quoted-quotes: true}\n')
+        self.check('---\n'
+                   'foo1: "[barbaz]"\n'          # fails
+                   'foo2: "[bar\'baz]"\n',
+                   conf, problem1=(2, 7))
+
+        conf = ('quoted-strings: {quote-type: single,\n'
+                '                 required: only-when-needed,\n'
+                '                 allow-quoted-quotes: false}\n')
+        self.check('---\n'
+                   'foo1: "[barbaz]"\n'          # fails
+                   'foo2: "[bar\'baz]"\n',       # fails
+                   conf, problem1=(2, 7), problem2=(3, 7))
+
+        conf = ('quoted-strings: {quote-type: single,\n'
+                '                 required: only-when-needed,\n'
+                '                 allow-quoted-quotes: true}\n')
+        self.check('---\n'
+                   'foo1: "[barbaz]"\n'          # fails
+                   'foo2: "[bar\'baz]"\n',
+                   conf, problem1=(2, 7))
+
+        conf = ('quoted-strings: {quote-type: double,\n'
+                '                 required: false,\n'
+                '                 allow-quoted-quotes: false}\n')
+        self.check("---\n"
+                   "foo1: '[barbaz]'\n"          # fails
+                   "foo2: '[bar\"baz]'\n",       # fails
+                   conf, problem1=(2, 7), problem2=(3, 7))
+
+        conf = ('quoted-strings: {quote-type: double,\n'
+                '                 required: false,\n'
+                '                 allow-quoted-quotes: true}\n')
+        self.check("---\n"
+                   "foo1: '[barbaz]'\n"          # fails
+                   "foo2: '[bar\"baz]'\n",
+                   conf, problem1=(2, 7))
+
+        conf = ('quoted-strings: {quote-type: double,\n'
+                '                 required: true,\n'
+                '                 allow-quoted-quotes: false}\n')
+        self.check("---\n"
+                   "foo1: '[barbaz]'\n"          # fails
+                   "foo2: '[bar\"baz]'\n",       # fails
+                   conf, problem1=(2, 7), problem2=(3, 7))
+
+        conf = ('quoted-strings: {quote-type: double,\n'
+                '                 required: true,\n'
+                '                 allow-quoted-quotes: true}\n')
+        self.check("---\n"
+                   "foo1: '[barbaz]'\n"          # fails
+                   "foo2: '[bar\"baz]'\n",
+                   conf, problem1=(2, 7))
+
+        conf = ('quoted-strings: {quote-type: double,\n'
+                '                 required: only-when-needed,\n'
+                '                 allow-quoted-quotes: false}\n')
+        self.check("---\n"
+                   "foo1: '[barbaz]'\n"          # fails
+                   "foo2: '[bar\"baz]'\n",       # fails
+                   conf, problem1=(2, 7), problem2=(3, 7))
+
+        conf = ('quoted-strings: {quote-type: double,\n'
+                '                 required: only-when-needed,\n'
+                '                 allow-quoted-quotes: true}\n')
+        self.check("---\n"
+                   "foo1: '[barbaz]'\n"          # fails
+                   "foo2: '[bar\"baz]'\n",
+                   conf, problem1=(2, 7))
+
+        conf = ('quoted-strings: {quote-type: any}\n')
+        self.check("---\n"
+                   "foo1: '[barbaz]'\n"
+                   "foo2: '[bar\"baz]'\n",
+                   conf)

--- a/yamllint/rules/quoted_strings.py
+++ b/yamllint/rules/quoted_strings.py
@@ -149,7 +149,7 @@ CONF = {'quote-type': ('any', 'single', 'double'),
         'required': (True, False, 'only-when-needed'),
         'extra-required': [str],
         'extra-allowed': [str],
-        'allow-quoted-quotes': (True, False)}
+        'allow-quoted-quotes': bool}
 DEFAULT = {'quote-type': 'any',
            'required': True,
            'extra-required': [],
@@ -225,7 +225,6 @@ def check(conf, token, prev, next, nextnext, context):
     if (not token.plain) and (token.style == "|" or token.style == ">"):
         return
 
-    # Check value is quoted qoute
     if (conf['allow-quoted-quotes'] is True and (not token.plain)
             and ((token.style == "'" and '"' in token.value) or
                  (token.style == '"' and "'" in token.value))):

--- a/yamllint/rules/quoted_strings.py
+++ b/yamllint/rules/quoted_strings.py
@@ -116,8 +116,7 @@ used.
     - "localhost"
     - this is a string that needs to be QUOTED
 
-#. With ``quoted-strings: {quote-type: double, required: true,
-   allow-quoted-quotes: false}``
+#. With ``quoted-strings: {quote-type: double, allow-quoted-quotes: false}``
 
    the following code snippet would **PASS**:
    ::
@@ -129,8 +128,7 @@ used.
 
     foo: 'bar"baz'
 
-#. With ``quoted-strings: {quote-type: double, required: true,
-   allow-quoted-quotes: true}``
+#. With ``quoted-strings: {quote-type: double, allow-quoted-quotes: true}``
 
    the following code snippet would **PASS**:
    ::

--- a/yamllint/rules/quoted_strings.py
+++ b/yamllint/rules/quoted_strings.py
@@ -166,8 +166,6 @@ def VALIDATE(conf):
         return 'cannot use both "required: true" and "extra-required"'
     if conf['required'] is False and len(conf['extra-allowed']) > 0:
         return 'cannot use both "required: false" and "extra-allowed"'
-    if conf['allow-quoted-quotes'] is True and conf['quote-type'] == 'any':
-        return '"allow-quoted-quotes" has no effect with "quote-type: any"'
 
 
 DEFAULT_SCALAR_TAG = u'tag:yaml.org,2002:str'

--- a/yamllint/rules/quoted_strings.py
+++ b/yamllint/rules/quoted_strings.py
@@ -30,7 +30,7 @@ used.
   ``required: false`` and  ``required: only-when-needed``.
 * ``extra-allowed`` is a list of PCRE regexes to allow quoted string values,
   even if ``required: only-when-needed`` is set.
-* ``skip-quoted-quote`` allows (``true``) using disallowed quotes for strings
+* ``allow-quoted-quotes`` allows (``true``) using disallowed quotes for strings
   with allowed quotes inside. Default ``false``.
 
 **Note**: Multi-line strings (with ``|`` or ``>``) will not be checked.
@@ -45,7 +45,7 @@ used.
      required: true
      extra-required: []
      extra-allowed: []
-     skip-quoted-quote: false
+     allow-quoted-quotes: false
 
 .. rubric:: Examples
 
@@ -117,7 +117,7 @@ used.
     - this is a string that needs to be QUOTED
 
 #. With ``quoted-strings: {quote-type: double, required: true,
-   skip-quoted-quote: false}``
+   allow-quoted-quotes: false}``
 
    the following code snippet would **PASS**:
    ::
@@ -130,7 +130,7 @@ used.
     foo: 'bar"baz'
 
 #. With ``quoted-strings: {quote-type: double, required: true,
-   skip-quoted-quote: true}``
+   allow-quoted-quotes: true}``
 
    the following code snippet would **PASS**:
    ::
@@ -151,12 +151,12 @@ CONF = {'quote-type': ('any', 'single', 'double'),
         'required': (True, False, 'only-when-needed'),
         'extra-required': [str],
         'extra-allowed': [str],
-        'skip-quoted-quote': (True, False)}
+        'allow-quoted-quotes': (True, False)}
 DEFAULT = {'quote-type': 'any',
            'required': True,
            'extra-required': [],
            'extra-allowed': [],
-           'skip-quoted-quote': False}
+           'allow-quoted-quotes': False}
 
 
 def VALIDATE(conf):
@@ -166,8 +166,8 @@ def VALIDATE(conf):
         return 'cannot use both "required: true" and "extra-required"'
     if conf['required'] is False and len(conf['extra-allowed']) > 0:
         return 'cannot use both "required: false" and "extra-allowed"'
-    if conf['skip-quoted-quote'] is True and conf['quote-type'] == 'any':
-        return '"skip-quoted-quote" has no effect with "quote-type: any"'
+    if conf['allow-quoted-quotes'] is True and conf['quote-type'] == 'any':
+        return '"allow-quoted-quotes" has no effect with "quote-type: any"'
 
 
 DEFAULT_SCALAR_TAG = u'tag:yaml.org,2002:str'
@@ -230,7 +230,7 @@ def check(conf, token, prev, next, nextnext, context):
         return
 
     # Check value is quoted qoute
-    if (conf['skip-quoted-quote'] is True and (not token.plain)
+    if (conf['allow-quoted-quotes'] is True and (not token.plain)
             and ((token.style == "'" and '"' in token.value) or
                  (token.style == '"' and "'" in token.value))):
         is_quoted_quote = True


### PR DESCRIPTION
This PR implements ~~`skip-quoted-quote`~~ `allow-quoted-quotes` option that allows strings like:
- `'foo"bar'` on `quote-type: double`
- `"foo'bar"` on `quote-type: single`

Closes use-case with quotes inside the string from #424. But still no solution for escape sequences.