### PR TITLE
quoted-strings: fix docs example

### DIFF
--- a/yamllint/rules/quoted_strings.py
+++ b/yamllint/rules/quoted_strings.py
@@ -121,7 +121,7 @@ used.
    the following code snippet would **PASS**:
    ::
 
-    foo: "bar\"baz"
+    foo: "bar\\"baz"
 
    the following code snippet would **FAIL**:
    ::


### PR DESCRIPTION
Fixes this from #487 

![](https://user-images.githubusercontent.com/5244945/183289236-55320312-d25f-42fd-80da-07785947aff7.png)
