### PR TITLE
fix: ensure indent-seq works in nested collections

### DIFF
--- a/tests/rules/test_indentation.py
+++ b/tests/rules/test_indentation.py
@@ -1370,6 +1370,45 @@ class IndentationTestCase(RuleTestCase):
                    '               key: value\n'
                    '...\n', conf, problem=(2, 2))
 
+    def test_nested_collections_with_spaces_consistent(self):
+        """Tests behavior of {spaces: consistent} in nested collections to
+        ensure wrong-indentation is properly caught--especially when the
+        expected indent value is initially unkown. For details, see
+        https://github.com/adrienverge/yamllint/issues/485.
+        """
+        conf = ('indentation: {spaces: consistent,\n'
+                '              indent-sequences: true}')
+        self.check('---\n'
+                   '- item:\n'
+                   '  - elem\n'
+                   '- item:\n'
+                   '    - elem\n'
+                   '...\n', conf, problem=(3, 3))
+        conf = ('indentation: {spaces: consistent,\n'
+                '              indent-sequences: false}')
+        self.check('---\n'
+                   '- item:\n'
+                   '  - elem\n'
+                   '- item:\n'
+                   '    - elem\n'
+                   '...\n', conf, problem=(5,5))
+        conf = ('indentation: {spaces: consistent,\n'
+                '              indent-sequences: consistent}')
+        self.check('---\n'
+                   '- item:\n'
+                   '  - elem\n'
+                   '- item:\n'
+                   '    - elem\n'
+                   '...\n', conf, problem=(5,5))
+        conf = ('indentation: {spaces: consistent,\n'
+                '              indent-sequences: whatever}')
+        self.check('---\n'
+                   '- item:\n'
+                   '  - elem\n'
+                   '- item:\n'
+                   '    - elem\n'
+                   '...\n', conf)
+
     def test_return(self):
         conf = 'indentation: {spaces: consistent}'
         self.check('---\n'

--- a/yamllint/rules/indentation.py
+++ b/yamllint/rules/indentation.py
@@ -341,9 +341,14 @@ def _check(conf, token, prev, next, nextnext, context):
             expected = detect_indent(expected, token)
 
         if found_indentation != expected:
-            yield LintProblem(token.start_mark.line + 1, found_indentation + 1,
-                              'wrong indentation: expected %d but found %d' %
-                              (expected, found_indentation))
+            if expected < 0:
+                message = 'wrong indentation: expected at least %d' % \
+                          (found_indentation + 1)
+            else:
+                message = 'wrong indentation: expected %d but found %d' % \
+                          (expected, found_indentation)
+            yield LintProblem(token.start_mark.line + 1,
+                              found_indentation + 1, message)
 
     if (isinstance(token, yaml.ScalarToken) and
             conf['check-multi-line-strings']):
@@ -493,8 +498,8 @@ def _check(conf, token, prev, next, nextnext, context):
                         # indentation it should have (because `spaces` is
                         # `consistent` and its value has not been computed yet
                         # -- this is probably the beginning of the document).
-                        # So we choose an arbitrary value (2).
-                        indent = 2
+                        # So we choose an unknown value (-1).
+                        indent = -1
                     else:
                         indent = detect_indent(context['stack'][-1].indent,
                                                next)


### PR DESCRIPTION
Currently, when spaces: consistent, and indent-sequences: true (the defaults), the expected indent for an unindented block sequence is arbitrarily set to 2 expecting it to be at the start of the document. Unfortunately, this causes a bug when the expected indent should be more than 2. For example, in nested collections like the one below, linting would pass, even though the expected indent is _at least_ 3  (since spaces: consistent doesn't enforce how many spaces should be used for indentation). I first reported this behavior in issue #485, which this PR resolves. 

```yaml
---
- item:
  - elem 1
  - elem 2 
```

Instead of setting the expected indent value to 2 arbitrarily, this change sets the value to -1, to explicitly indicate that indentation is required, but the expected indent value is unknown. The problem description that is returned when this wrong indentation is caught then displays the minimum number of spaces expected, since that is known (indent found + 1)

```
3:3       error    wrong indentation: expected at least 3  (indentation)
```

As a side effect, this also fixes a minor related bug I uncovered where the expected indentation printed when linting a nested collection like the one below, is always 2, even though _1 or more_ would also be acceptable with spaces: consistent. 

```yaml
---
item:
- elem 1
- elem 2 
``` 