### PR TITLE
ci: Python 3.6 reached end-of-life on 2021-12-23

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -34,7 +34,6 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-          - '3.6'
           - '3.7'
           - '3.8'
           - '3.9'

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,7 +27,6 @@ classifiers =
   Intended Audience :: Developers
   License :: OSI Approved :: GNU General Public License v3 (GPLv3)
   Programming Language :: Python :: 3
-  Programming Language :: Python :: 3.6
   Programming Language :: Python :: 3.7
   Programming Language :: Python :: 3.8
   Programming Language :: Python :: 3.9
@@ -46,7 +45,7 @@ project_urls =
 [options]
 packages = find:
 
-python_requires = >=3.6
+python_requires = >=3.7
 
 include_package_data = True
 install_requires =


### PR DESCRIPTION
https://peps.python.org/pep-0494/