### PR TITLE
style: Fix indentation test file missing whitespace

### DIFF
--- a/tests/rules/test_indentation.py
+++ b/tests/rules/test_indentation.py
@@ -1391,7 +1391,7 @@ class IndentationTestCase(RuleTestCase):
                    '  - elem\n'
                    '- item:\n'
                    '    - elem\n'
-                   '...\n', conf, problem=(5,5))
+                   '...\n', conf, problem=(5, 5))
         conf = ('indentation: {spaces: consistent,\n'
                 '              indent-sequences: consistent}')
         self.check('---\n'
@@ -1399,7 +1399,7 @@ class IndentationTestCase(RuleTestCase):
                    '  - elem\n'
                    '- item:\n'
                    '    - elem\n'
-                   '...\n', conf, problem=(5,5))
+                   '...\n', conf, problem=(5, 5))
         conf = ('indentation: {spaces: consistent,\n'
                 '              indent-sequences: whatever}')
         self.check('---\n'


### PR DESCRIPTION
Commit 764586d "indentation: Fix indent-sequences in nested collections" introduced 2 style-related problems:

    tests/rules/test_indentation.py:1394:45: E231 missing whitespace after ','
    tests/rules/test_indentation.py:1402:45: E231 missing whitespace after ','

Let's fix them.