### PR TITLE
CI: Fix Sphinx-related errors on 'linter' step

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,8 +21,8 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
       - run:
-          python -m pip install flake8 flake8-import-order doc8 sphinx
-            rstcheck[sphinx]
+          python -m pip install flake8 flake8-import-order sphinx
+            rstcheck[sphinx] doc8
       - run: python -m pip install .
       - run: flake8 .
       - run: doc8 $(git ls-files '*.rst')

--- a/docs/disable_with_comments.rst
+++ b/docs/disable_with_comments.rst
@@ -117,7 +117,7 @@ post-template processing).
 Example of a Jinja2 code that cannot be parsed as YAML because it contains
 invalid tokens ``{%`` and ``%}``:
 
-.. code-block:: yaml
+.. code-block::
 
  # This file IS NOT valid YAML and will procuce syntax errors
  {% if extra_info %}


### PR DESCRIPTION
### docs: Fix Sphinx error on non-YAML code snippet

This problem was just introduced by commit cec4f33 "Clarify disable-line
and parser errors, workaround" and produced this error when building
documentation:

    docs/disable_with_comments.rst:120:Could not lex literal_block as
    "yaml". Highlighting skipped.

---

### CI: Fix pip install problem with Pygments version

Recently `python setup.py build_sphinx` started failing with:

    pkg_resources.VersionConflict: (Pygments 2.3.1
    (/usr/lib/python3/dist-packages), Requirement.parse('Pygments>=2.12'))

The reason is that `doc8` 1.0.0 installs `Pygments` 2.3.1, then `Sphinx`
5.3.0 needs `Pygments` ≥ 2.12.

The easiest fix is to change the install order.
