### PR TITLE
All strings are Unicode in Python 3

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -38,7 +38,7 @@ htmlhelp_basename = 'yamllintdoc'
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
 man_pages = [
-    ('index', 'yamllint', 'Linter for YAML files', [u'Adrien Vergé'], 1)
+    ('index', 'yamllint', 'Linter for YAML files', ['Adrien Vergé'], 1)
 ]
 
 # -- Build with sphinx automodule without needing to install third-party libs

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -92,12 +92,12 @@ class CommandLineTestCase(unittest.TestCase):
             'no-yaml.json': '---\n'
                             'key: value\n',
             # non-ASCII chars
-            u'non-ascii/éçäγλνπ¥/utf-8': (
-                u'---\n'
-                u'- hétérogénéité\n'
-                u'# 19.99 €\n'
-                u'- お早う御座います。\n'
-                u'# الأَبْجَدِيَّة العَرَبِيَّة\n').encode('utf-8'),
+            'non-ascii/éçäγλνπ¥/utf-8': (
+                '---\n'
+                '- hétérogénéité\n'
+                '# 19.99 €\n'
+                '- お早う御座います。\n'
+                '# الأَبْجَدِيَّة العَرَبِيَّة\n').encode('utf-8'),
             # dos line endings yaml
             'dos.yml': '---\r\n'
                        'dos: true',

--- a/tests/test_linter.py
+++ b/tests/test_linter.py
@@ -31,10 +31,10 @@ class LinterTestCase(unittest.TestCase):
         linter.run(b'test: document', self.fake_config())
 
     def test_run_on_unicode(self):
-        linter.run(u'test: document', self.fake_config())
+        linter.run('test: document', self.fake_config())
 
     def test_run_on_stream(self):
-        linter.run(io.StringIO(u'hello'), self.fake_config())
+        linter.run(io.StringIO('hello'), self.fake_config())
 
     def test_run_on_int(self):
         self.assertRaises(TypeError, linter.run, 42, self.fake_config())
@@ -44,14 +44,14 @@ class LinterTestCase(unittest.TestCase):
                           ['h', 'e', 'l', 'l', 'o'], self.fake_config())
 
     def test_run_on_non_ascii_chars(self):
-        s = (u'- hétérogénéité\n'
-             u'# 19.99 €\n')
+        s = ('- hétérogénéité\n'
+             '# 19.99 €\n')
         linter.run(s, self.fake_config())
         linter.run(s.encode('utf-8'), self.fake_config())
         linter.run(s.encode('iso-8859-15'), self.fake_config())
 
-        s = (u'- お早う御座います。\n'
-             u'# الأَبْجَدِيَّة العَرَبِيَّة\n')
+        s = ('- お早う御座います。\n'
+             '# الأَبْجَدِيَّة العَرَبِيَّة\n')
         linter.run(s, self.fake_config())
         linter.run(s.encode('utf-8'), self.fake_config())
 

--- a/yamllint/__init__.py
+++ b/yamllint/__init__.py
@@ -24,7 +24,7 @@ APP_NAME = 'yamllint'
 APP_VERSION = '1.28.0'
 APP_DESCRIPTION = __doc__
 
-__author__ = u'Adrien Vergé'
-__copyright__ = u'Copyright 2022, Adrien Vergé'
+__author__ = 'Adrien Vergé'
+__copyright__ = 'Copyright 2022, Adrien Vergé'
 __license__ = 'GPLv3'
 __version__ = APP_VERSION

--- a/yamllint/rules/quoted_strings.py
+++ b/yamllint/rules/quoted_strings.py
@@ -166,7 +166,7 @@ def VALIDATE(conf):
         return 'cannot use both "required: false" and "extra-allowed"'
 
 
-DEFAULT_SCALAR_TAG = u'tag:yaml.org,2002:str'
+DEFAULT_SCALAR_TAG = 'tag:yaml.org,2002:str'
 
 # https://stackoverflow.com/a/36514274
 yaml.resolver.Resolver.add_implicit_resolver(


### PR DESCRIPTION
No need for `u'€'`, just use `'€'`.