### PR TITLE
Apply some pyupgrade suggestions

### DIFF
--- a/tests/test_spec_examples.py
+++ b/tests/test_spec_examples.py
@@ -13,7 +13,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from io import open
 import os
 
 from tests.common import RuleTestCase

--- a/yamllint/cli.py
+++ b/yamllint/cli.py
@@ -14,7 +14,6 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import argparse
-import io
 import locale
 import os
 import platform
@@ -213,9 +212,9 @@ def run(argv=None):
     for file in find_files_recursively(args.files, conf):
         filepath = file[2:] if file.startswith('./') else file
         try:
-            with io.open(file, newline='') as f:
+            with open(file, newline='') as f:
                 problems = linter.run(f, conf, filepath)
-        except EnvironmentError as e:
+        except OSError as e:
             print(e, file=sys.stderr)
             sys.exit(-1)
         prob_level = show_problems(problems, file, args_format=args.format,
@@ -226,7 +225,7 @@ def run(argv=None):
     if args.stdin:
         try:
             problems = linter.run(sys.stdin, conf, '')
-        except EnvironmentError as e:
+        except OSError as e:
             print(e, file=sys.stderr)
             sys.exit(-1)
         prob_level = show_problems(problems, 'stdin', args_format=args.format,

--- a/yamllint/parser.py
+++ b/yamllint/parser.py
@@ -132,8 +132,7 @@ def token_or_comment_generator(buffer):
 
             yield Token(curr.start_mark.line + 1, curr, prev, next, nextnext)
 
-            for comment in comments_between_tokens(curr, next):
-                yield comment
+            yield from comments_between_tokens(curr, next)
 
             prev = curr
             curr = next

--- a/yamllint/rules/indentation.py
+++ b/yamllint/rules/indentation.py
@@ -352,8 +352,7 @@ def _check(conf, token, prev, next, nextnext, context):
 
     if (isinstance(token, yaml.ScalarToken) and
             conf['check-multi-line-strings']):
-        for problem in check_scalar_indentation(conf, token, context):
-            yield problem
+        yield from check_scalar_indentation(conf, token, context)
 
     # Step 2.a:
 
@@ -581,8 +580,7 @@ def _check(conf, token, prev, next, nextnext, context):
 
 def check(conf, token, prev, next, nextnext, context):
     try:
-        for problem in _check(conf, token, prev, next, nextnext, context):
-            yield problem
+        yield from _check(conf, token, prev, next, nextnext, context)
     except AssertionError:
         yield LintProblem(token.start_mark.line + 1,
                           token.start_mark.column + 1,


### PR DESCRIPTION
* `io.open()` is an alias for for the builtin `open()` function:
  	https://docs.python.org/3/library/io.html#io.open
* If `open()` cannot open a file, an `OSError` is raised:
  	https://docs.python.org/3/library/functions.html#open
* `EnvironmentError` is kept for compatibility with previous versions; starting from Python 3.3, it is an alias of `OSError`:
  https://docs.python.org/3/library/exceptions.html#EnvironmentError
* Directly yield from an iterable instead of iterating to yield items.