### PR TITLE
feat: Add --list-files command line option

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -136,6 +136,13 @@ directories, set ``yaml-files`` configuration option. The default is:
 The same rules as for ignoring paths apply (``.gitignore``-style path pattern,
 see below).
 
+If you need to know the exact list of files that yamllint would process,
+without really linting them, you can use ``--list-files``:
+
+.. code:: bash
+
+ yamllint --list-files .
+
 Ignoring paths
 --------------
 
@@ -203,6 +210,13 @@ or:
  ignore-from-file: [.gitignore, .yamlignore]
 
 .. note:: However, this is mutually exclusive with the ``ignore`` key.
+
+If you need to know the exact list of files that yamllint would process,
+without really linting them, you can use ``--list-files``:
+
+.. code:: bash
+
+ yamllint --list-files .
 
 Setting the locale
 ------------------

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -678,6 +678,39 @@ class CommandLineTestCase(unittest.TestCase):
         self.assertEqual(
             (ctx.returncode, ctx.stdout, ctx.stderr), (1, expected_out, ''))
 
+    def test_run_list_files(self):
+        with RunContext(self) as ctx:
+            cli.run(('--list-files', self.wd))
+        self.assertEqual(ctx.returncode, 0)
+        self.assertEqual(
+            sorted(ctx.stdout.splitlines()),
+            [os.path.join(self.wd, 'a.yaml'),
+             os.path.join(self.wd, 'c.yaml'),
+             os.path.join(self.wd, 'dos.yml'),
+             os.path.join(self.wd, 'empty.yml'),
+             os.path.join(self.wd, 'en.yaml'),
+             os.path.join(self.wd, 's/s/s/s/s/s/s/s/s/s/s/s/s/s/s/file.yaml'),
+             os.path.join(self.wd, 'sub/directory.yaml/empty.yml'),
+             os.path.join(self.wd, 'sub/ok.yaml'),
+             os.path.join(self.wd, 'warn.yaml')]
+        )
+
+        config = '{ignore: "*.yml", yaml-files: ["*.*"]}'
+        with RunContext(self) as ctx:
+            cli.run(('--list-files', '-d', config, self.wd))
+        self.assertEqual(ctx.returncode, 0)
+        self.assertEqual(
+            sorted(ctx.stdout.splitlines()),
+            [os.path.join(self.wd, 'a.yaml'),
+             os.path.join(self.wd, 'c.yaml'),
+             os.path.join(self.wd, 'en.yaml'),
+             os.path.join(self.wd, 'no-yaml.json'),
+             os.path.join(self.wd, 's/s/s/s/s/s/s/s/s/s/s/s/s/s/s/file.yaml'),
+             os.path.join(self.wd, 'sub/directory.yaml/not-yaml.txt'),
+             os.path.join(self.wd, 'sub/ok.yaml'),
+             os.path.join(self.wd, 'warn.yaml')]
+        )
+
 
 class CommandLineConfigTestCase(unittest.TestCase):
     def test_config_file(self):

--- a/yamllint/cli.py
+++ b/yamllint/cli.py
@@ -157,6 +157,8 @@ def run(argv=None):
     config_group.add_argument('-d', '--config-data', dest='config_data',
                               action='store',
                               help='custom configuration (as YAML source)')
+    parser.add_argument('--list-files', action='store_true', dest='list_files',
+                        help='list files to lint and exit')
     parser.add_argument('-f', '--format',
                         choices=('parsable', 'standard', 'colored', 'github',
                                  'auto'),
@@ -206,6 +208,12 @@ def run(argv=None):
 
     if conf.locale is not None:
         locale.setlocale(locale.LC_ALL, conf.locale)
+
+    if args.list_files:
+        for file in find_files_recursively(args.files, conf):
+            if not conf.is_file_ignored(file):
+                print(file)
+        sys.exit(0)
 
     max_level = 0
 


### PR DESCRIPTION
## What?

This PR adds the command line option `--list-files` which list files to lint and exits.

## Why?

This is useful to determine which files are being linted to check configuration changes like `yaml-files` and `ignore` more conveniently.

## Usage

```
$ yamllint -h
usage: yamllint [-h] [-] [-c CONFIG_FILE | -d CONFIG_DATA] [-f {parsable,standard,colored,github,auto}] [-s]
                [--no-warnings] [-v]
                [FILE_OR_DIR ...]

A linter for YAML files. yamllint does not only check for syntax validity, but for weirdnesses like key
repetition and cosmetic problems such as lines length, trailing spaces, indentation, etc.

positional arguments:
  FILE_OR_DIR           files to check

optional arguments:
  -h, --help            show this help message and exit
  -                     read from standard input
  -c CONFIG_FILE, --config-file CONFIG_FILE
                        path to a custom configuration
  -d CONFIG_DATA, --config-data CONFIG_DATA
                        custom configuration (as YAML source)
  --list-files      list files to lint and exit
  -f {parsable,standard,colored,github,auto}, --format {parsable,standard,colored,github,auto}
                        format for parsing output
  -s, --strict          return non-zero exit code on warnings as well as errors
  --no-warnings         output only error level problems
  -v, --version         show program's version number and exit
```

```bash
$ yamllint --list-files .
./.pre-commit-hooks.yaml
./yamllint/conf/default.yaml
./yamllint/conf/relaxed.yaml
./.github/workflows/ci.yaml
``` 

## Docs

![Screenshot from 2023-01-07 12-07-45](https://user-images.githubusercontent.com/28908/211147156-b2e6d25e-0aee-4a49-ac3f-4b363b02417c.png)
![Screenshot from 2023-01-07 12-07-24](https://user-images.githubusercontent.com/28908/211147157-51a8bd4a-edff-4476-8e7d-96acd2a8bebd.png)


## Refs

* https://github.com/adrienverge/yamllint/issues/396

