### PR TITLE
Allow using a list of strings in ignore configuration

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -140,7 +140,8 @@ Ignoring paths
 --------------
 
 It is possible to exclude specific files or directories, so that the linter
-doesn't process them.
+doesn't process them. They can be provided either as a list of paths, or as a
+bulk string.
 
 You can either totally ignore files (they won't be looked at):
 
@@ -153,6 +154,13 @@ You can either totally ignore files (they won't be looked at):
    all/this/directory/
    *.template.yaml
 
+ # or:
+
+ ignore:
+   - /this/specific/file.yaml
+   - all/this/directory/
+   - '*.template.yaml'
+
 or ignore paths only for specific rules:
 
 .. code-block:: yaml
@@ -164,6 +172,14 @@ or ignore paths only for specific rules:
      ignore: |
        /this-file-has-trailing-spaces-but-it-is-OK.yaml
        /generated/*.yaml
+
+ # or:
+
+ rules:
+   trailing-spaces:
+     ignore:
+       - /this-file-has-trailing-spaces-but-it-is-OK.yaml
+       - /generated/*.yaml
 
 Note that this ``.gitignore``-style path pattern allows complex path
 exclusion/inclusion, see the `pathspec README file

--- a/yamllint/config.py
+++ b/yamllint/config.py
@@ -112,11 +112,16 @@ class YamlLintConfig:
             with fileinput.input(conf['ignore-from-file']) as f:
                 self.ignore = pathspec.PathSpec.from_lines('gitwildmatch', f)
         elif 'ignore' in conf:
-            if not isinstance(conf['ignore'], str):
+            if isinstance(conf['ignore'], str):
+                self.ignore = pathspec.PathSpec.from_lines(
+                    'gitwildmatch', conf['ignore'].splitlines())
+            elif (isinstance(conf['ignore'], list) and
+                    all(isinstance(line, str) for line in conf['ignore'])):
+                self.ignore = pathspec.PathSpec.from_lines(
+                    'gitwildmatch', conf['ignore'])
+            else:
                 raise YamlLintConfigError(
                     'invalid config: ignore should contain file patterns')
-            self.ignore = pathspec.PathSpec.from_lines(
-                'gitwildmatch', conf['ignore'].splitlines())
 
         if 'yaml-files' in conf:
             if not (isinstance(conf['yaml-files'], list)
@@ -150,11 +155,16 @@ def validate_rule_conf(rule, conf):
     if isinstance(conf, dict):
         if ('ignore' in conf and
                 not isinstance(conf['ignore'], pathspec.pathspec.PathSpec)):
-            if not isinstance(conf['ignore'], str):
+            if isinstance(conf['ignore'], str):
+                conf['ignore'] = pathspec.PathSpec.from_lines(
+                    'gitwildmatch', conf['ignore'].splitlines())
+            elif (isinstance(conf['ignore'], list) and
+                    all(isinstance(line, str) for line in conf['ignore'])):
+                conf['ignore'] = pathspec.PathSpec.from_lines(
+                    'gitwildmatch', conf['ignore'])
+            else:
                 raise YamlLintConfigError(
                     'invalid config: ignore should contain file patterns')
-            conf['ignore'] = pathspec.PathSpec.from_lines(
-                'gitwildmatch', conf['ignore'].splitlines())
 
         if 'level' not in conf:
             conf['level'] = 'error'


### PR DESCRIPTION
This may feel more natural for some users, rather than embedding multiple entries in a multi-line string.