### PR TITLE
Fix misleading Python API example

### DIFF
--- a/docs/development.rst
+++ b/docs/development.rst
@@ -11,7 +11,7 @@ Basic example of running the linter from Python:
    import yamllint
 
    yaml_config = yamllint.config.YamlLintConfig("extends: default")
-   for p in yamllint.linter.run("example.yaml", yaml_config):
+   for p in yamllint.linter.run(open("example.yaml", "r"), yaml_config):
        print(p.desc, p.line, p.rule)
 
 .. automodule:: yamllint.linter


### PR DESCRIPTION
`yamllint.linter.run("example.yaml", yaml_config)` example seems `yamllint.linter.run` opens a given file.
It's misleading.