### PR TITLE
docs: Explicitly specify language even when it's plain text

### DIFF
--- a/docs/disable_with_comments.rst
+++ b/docs/disable_with_comments.rst
@@ -117,7 +117,7 @@ post-template processing).
 Example of a Jinja2 code that cannot be parsed as YAML because it contains
 invalid tokens ``{%`` and ``%}``:
 
-.. code-block::
+.. code-block:: text
 
  # This file IS NOT valid YAML and will produce syntax errors
  {% if extra_info %}


### PR DESCRIPTION
rstcheck succeeds with a failure (heh) when there's a code block without a language specified. This can lead to false negatives as the file is no longer being checked by rstcheck.

Error:

    An `AttributeError` error occured. This is most propably due to a
    code block directive (code/code-block/sourcecode) without a
    specified language. This may result in a false negative for source:
    'docs/disable_with_comments.rst'. See
    https://rstcheck-core.readthedocs.io/en/latest/faq/#code-blocks-without-language-sphinx
    for more information.  Success! No issues detected.
