### PR TITLE
Avoid runtime exception caused by newer pathspec

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -44,6 +44,11 @@ class SimpleConfigTestCase(unittest.TestCase):
         with self.assertRaises(config.YamlLintConfigError):
             config.YamlLintConfig('not: valid: yaml')
 
+    def test_is_file_ignored_allows_none(self):
+        c = config.YamlLintConfig('ignore: foobar\n')
+        self.assertTrue(c.is_file_ignored('foobar'))
+        self.assertFalse(c.is_file_ignored(None))
+
     def test_unknown_rule(self):
         with self.assertRaisesRegex(
                 config.YamlLintConfigError,

--- a/yamllint/config.py
+++ b/yamllint/config.py
@@ -45,7 +45,7 @@ class YamlLintConfig:
         self.validate()
 
     def is_file_ignored(self, filepath):
-        return self.ignore and self.ignore.match_file(filepath)
+        return self.ignore and filepath and self.ignore.match_file(filepath)
 
     def is_yaml_file(self, filepath):
         return self.yaml_files.match_file(os.path.basename(filepath))


### PR DESCRIPTION
Some changes made in the minor pathspec update recently released break yamllint. This makes the code work with newer version too.

- pathspec==0.11.0 worked
- pathspec==0.11.1 no longer works, fixed by this change

See: https://github.com/ansible/ansible-lint/actions/runs/4439000759/jobs/7790864220?pr=3194