### PR TITLE
linter: Prevent testing is_file_ignored() with filepath == None

### DIFF
--- a/yamllint/linter.py
+++ b/yamllint/linter.py
@@ -223,7 +223,7 @@ def run(input, conf, filepath=None):
     :param input: buffer, string or stream to read from
     :param conf: yamllint configuration object
     """
-    if conf.is_file_ignored(filepath):
+    if filepath is not None and conf.is_file_ignored(filepath):
         return ()
 
     if isinstance(input, (bytes, str)):


### PR DESCRIPTION
As reported in https://github.com/adrienverge/yamllint/pull/548, there might be a problem with pathspec 0.11.1 which does't allow calling `match_file()` with argument `None` anymore.

The `linter.run()` function shouldn't call `YamlLintConfig.is_file_ignored(None)` anyway.