### PR TITLE
Updated the version specifier in the document to latest

### DIFF
--- a/docs/integration.rst
+++ b/docs/integration.rst
@@ -14,7 +14,7 @@ Here is an example, to add in your .pre-commit-config.yaml
   # You can pass your custom .yamllint with args attribute.
   repos:
     - repo: https://github.com/adrienverge/yamllint.git
-      rev: v1.29.0
+      rev: v1.30.0
       hooks:
         - id: yamllint
           args: [--strict, -c=/path/to/.yamllint]


### PR DESCRIPTION
Usage examples in the current documentation do not refer to the latest version, so users may mistakenly refer to older versions.
To prevent this, the usage examples in the documentation now refer to the latest version.