### PR TITLE
Adapt 'anchors' and 'colons' for the required space after an alias key

### DIFF
--- a/tests/rules/test_anchors.py
+++ b/tests/rules/test_anchors.py
@@ -46,7 +46,7 @@ class AnchorsTestCase(RuleTestCase):
                    '  <<: *b_m\n'
                    '  foo: bar\n'
                    '---\n'
-                   '{a: 1, &x b: 2, c: &y 3, *x: 4, e: *y}\n'
+                   '{a: 1, &x b: 2, c: &y 3, *x : 4, e: *y}\n'
                    '...\n', conf)
         self.check('---\n'
                    '- &i 42\n'
@@ -74,7 +74,7 @@ class AnchorsTestCase(RuleTestCase):
                    '  <<: *b_m\n'
                    '  foo: bar\n'
                    '---\n'
-                   '{a: 1, &x b: 2, c: &x 3, *x: 4, e: *y}\n'
+                   '{a: 1, &x b: 2, c: &x 3, *x : 4, e: *y}\n'
                    '...\n', conf)
 
     def test_forbid_undeclared_aliases(self):
@@ -106,7 +106,7 @@ class AnchorsTestCase(RuleTestCase):
                    '  <<: *b_m\n'
                    '  foo: bar\n'
                    '---\n'
-                   '{a: 1, &x b: 2, c: &y 3, *x: 4, e: *y}\n'
+                   '{a: 1, &x b: 2, c: &y 3, *x : 4, e: *y}\n'
                    '...\n', conf)
         self.check('---\n'
                    '- &i 42\n'
@@ -134,7 +134,7 @@ class AnchorsTestCase(RuleTestCase):
                    '  <<: *b_m\n'
                    '  foo: bar\n'
                    '---\n'
-                   '{a: 1, &x b: 2, c: &x 3, *x: 4, e: *y}\n'
+                   '{a: 1, &x b: 2, c: &x 3, *x : 4, e: *y}\n'
                    '...\n', conf,
                    problem1=(9, 3),
                    problem2=(10, 3),
@@ -142,7 +142,7 @@ class AnchorsTestCase(RuleTestCase):
                    problem4=(12, 3),
                    problem5=(13, 3),
                    problem6=(24, 7),
-                   problem7=(27, 36))
+                   problem7=(27, 37))
 
     def test_forbid_duplicated_anchors(self):
         conf = ('anchors:\n'
@@ -173,7 +173,7 @@ class AnchorsTestCase(RuleTestCase):
                    '  <<: *b_m\n'
                    '  foo: bar\n'
                    '---\n'
-                   '{a: 1, &x b: 2, c: &y 3, *x: 4, e: *y}\n'
+                   '{a: 1, &x b: 2, c: &y 3, *x : 4, e: *y}\n'
                    '...\n', conf)
         self.check('---\n'
                    '- &i 42\n'
@@ -201,7 +201,7 @@ class AnchorsTestCase(RuleTestCase):
                    '  <<: *b_m\n'
                    '  foo: bar\n'
                    '---\n'
-                   '{a: 1, &x b: 2, c: &x 3, *x: 4, e: *y}\n'
+                   '{a: 1, &x b: 2, c: &x 3, *x : 4, e: *y}\n'
                    '...\n', conf,
                    problem1=(5, 3),
                    problem2=(6, 3),

--- a/tests/rules/test_colons.py
+++ b/tests/rules/test_colons.py
@@ -256,3 +256,19 @@ class ColonTestCase(RuleTestCase):
                    '  property: {a: 1, b:  2, c : 3}\n', conf,
                    problem1=(3, 11), problem2=(4, 4),
                    problem3=(8, 23), problem4=(8, 28))
+
+    # Although accepted by PyYAML, `{*x: 4}` is not valid YAML: it should be
+    # noted `{*x : 4}`. The reason is that a colon can be part of an anchor
+    # name. See commit message for more details.
+    def test_with_alias_as_key(self):
+        conf = 'colons: {max-spaces-before: 0, max-spaces-after: 1}'
+        self.check('---\n'
+                   '- anchor: &a key\n'
+                   '- *a: 42\n'
+                   '- {*a: 42}\n'
+                   '- *a : 42\n'
+                   '- {*a : 42}\n'
+                   '- *a  : 42\n'
+                   '- {*a  : 42}\n',
+                   conf,
+                   problem1=(7, 6), problem2=(8, 7))

--- a/yamllint/rules/colons.py
+++ b/yamllint/rules/colons.py
@@ -92,7 +92,9 @@ DEFAULT = {'max-spaces-before': 0,
 
 
 def check(conf, token, prev, next, nextnext, context):
-    if isinstance(token, yaml.ValueToken):
+    if isinstance(token, yaml.ValueToken) and not (
+            isinstance(prev, yaml.AliasToken) and
+            token.start_mark.pointer - prev.end_mark.pointer == 1):
         problem = spaces_before(token, prev, next,
                                 max=conf['max-spaces-before'],
                                 max_desc='too many spaces before colon')


### PR DESCRIPTION
### anchors: Fix invalid YAML in aliases test cases

Although accepted by PyYAML, `{*x: 4}` is not valid YAML: it should be
noted `{*x : 4}`. The reason is that a colon can be part of an anchor
name. See this comment from Tina Müller for more details:
https://github.com/adrienverge/yamllint/pull/550#discussion_r1155297373

Even if it's not a problem for yamllint, let's fix our tests to include
valid YAML snippets.

---

### colons: Prevent error when space before is mandatory

In the rare case when the key before `:` is an alias (e.g. `{*x : 4}`),
the space before `:` is required (although this requirement is not
enforced by PyYAML), the reason being that a colon can be part of an
anchor name. Consequently, this commit adapts the `colons` rule to avoid
failures when this happens.

See this comment from Tina Müller for more details:
https://github.com/adrienverge/yamllint/pull/550#discussion_r1155297373
