### PR TITLE
README: Update CI status badge

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -8,8 +8,8 @@ repetition and cosmetic problems such as lines length, trailing spaces,
 indentation, etc.
 
 .. image::
-   https://travis-ci.org/adrienverge/yamllint.svg?branch=master
-   :target: https://travis-ci.org/adrienverge/yamllint
+   https://github.com/adrienverge/yamllint/actions/workflows/ci.yaml/badge.svg?branch=master
+   :target: https://github.com/adrienverge/yamllint/actions/workflows/ci.yaml?query=branch%3Amaster
    :alt: CI tests status
 .. image::
    https://coveralls.io/repos/github/adrienverge/yamllint/badge.svg?branch=master


### PR DESCRIPTION
It is a leftover from commit 66bf76a "CI: Switch to GitHub Actions".