### PR TITLE
build: Stop using setup.py to generate documentation

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,7 +28,7 @@ jobs:
       - run: doc8 $(git ls-files '*.rst')
       - run: rstcheck --ignore-directives automodule $(git ls-files '*.rst')
       - run: yamllint --strict $(git ls-files '*.yaml' '*.yml')
-      - run: python setup.py build_sphinx
+      - run: make -C docs html
       - name: Check for broken links in documentation
         run: make -C docs linkcheck
 

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -2,7 +2,7 @@
 #
 
 # You can set these variables from the command line.
-SPHINXOPTS    =
+SPHINXOPTS    = -W
 SPHINXBUILD   = sphinx-build
 PAPER         =
 BUILDDIR      = _build

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,12 +3,6 @@ import-order-style = pep8
 application-import-names = yamllint
 ignore = W503,W504
 
-[build_sphinx]
-all-files = 1
-source-dir = docs
-build-dir = docs/_build
-warning-is-error = 1
-
 [metadata]
 keywords =
   yaml


### PR DESCRIPTION
Because `setup.py` is deprecated, let's switch from:

    python setup.py build_sphinx

to:

    make -C docs html

to build Sphinx documentation.

The generated HTML files in `docs/_build/html` are exactly the same (I compared with `diff -qr`).

Also add `-W` (turn warnings into errors) to the `sphinx-build` options to keep the previous behavior.