### PR TITLE
anchors: Add missing quotes in unused anchor error message

### DIFF
--- a/yamllint/rules/anchors.py
+++ b/yamllint/rules/anchors.py
@@ -168,7 +168,7 @@ def check(conf, token, prev, next, nextnext, context):
             conf['forbid-unused-anchors']):
         if isinstance(token, yaml.AnchorToken):
             context['anchors'][token.value] = {
-                "line": token.start_mark.line,
-                "column": token.start_mark.column,
-                "used": False
+                'line': token.start_mark.line,
+                'column': token.start_mark.column,
+                'used': False
             }

--- a/yamllint/rules/anchors.py
+++ b/yamllint/rules/anchors.py
@@ -159,7 +159,7 @@ def check(conf, token, prev, next, nextnext, context):
                 if not info['used']:
                     yield LintProblem(info['line'] + 1,
                                       info['column'] + 1,
-                                      f"found unused anchor {anchor}")
+                                      f'found unused anchor "{anchor}"')
         elif isinstance(token, yaml.AliasToken):
             context['anchors'].get(token.value, {})['used'] = True
 


### PR DESCRIPTION
### anchors: Add missing quotes in unused anchor error message

Existing `anchors` options use quotes around the anchor name:

    2:3       error    found undeclared alias "unknown"  (anchors)
    4:3       error    found duplicated anchor "dup"  (anchors)

Let's do the same in the newly-added option `forbid-unused-anchors`:

    5:3       error    found unused anchor "not used"  (anchors)

---

### anchors: Update code style to use single quotes

Like the rest of the project does.
