### PR TITLE
document-end: Fix spurious "missing document end"

### DIFF
--- a/tests/rules/test_document_end.py
+++ b/tests/rules/test_document_end.py
@@ -71,3 +71,22 @@ class DocumentEndTestCase(RuleTestCase):
                    '---\n'
                    'third: document\n'
                    '...\n', conf, problem=(6, 1))
+
+    def test_directives(self):
+        conf = 'document-end: {present: true}'
+        self.check('%YAML 1.2\n'
+                   '---\n'
+                   'document: end\n'
+                   '...\n', conf)
+        self.check('%YAML 1.2\n'
+                   '%TAG ! tag:clarkevans.com,2002:\n'
+                   '---\n'
+                   'document: end\n'
+                   '...\n', conf)
+        self.check('---\n'
+                   'first: document\n'
+                   '...\n'
+                   '%YAML 1.2\n'
+                   '---\n'
+                   'second: document\n'
+                   '...\n', conf)

--- a/yamllint/rules/document_end.py
+++ b/yamllint/rules/document_end.py
@@ -99,11 +99,13 @@ def check(conf, token, prev, next, nextnext, context):
         prev_is_end_or_stream_start = isinstance(
             prev, (yaml.DocumentEndToken, yaml.StreamStartToken)
         )
+        prev_is_directive = isinstance(prev, yaml.DirectiveToken)
 
         if is_stream_end and not prev_is_end_or_stream_start:
             yield LintProblem(token.start_mark.line, 1,
                               'missing document end "..."')
-        elif is_start and not prev_is_end_or_stream_start:
+        elif is_start and not (prev_is_end_or_stream_start
+                               or prev_is_directive):
             yield LintProblem(token.start_mark.line + 1, 1,
                               'missing document end "..."')
 


### PR DESCRIPTION
Fixes #560 when DocumentStartToken is preceded by `DirectiveToken`.