### PR TITLE
Document that GitHub Actions already installs `yamllint`

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -4,6 +4,9 @@ Quickstart
 Installing yamllint
 -------------------
 
+``yamllint`` is pre-installed on some systems (see the `GitHub Actions example <https://github.com/adrienverge/yamllint/pull/588#issuecomment-1679943422>`_).
+Otherwise, here is how to install it on some popular OSes.
+
 On Fedora / CentOS (note: `EPEL <https://docs.fedoraproject.org/en-US/epel/>`_ is
 required on CentOS):
 


### PR DESCRIPTION
I was looking up instructions for how to install `yamllint` so that I could use it in our GitHub actions workflow when I happened to see mention that it's already installed in the base image.

So adding a quick note here.

I phrased the note generically because additional CI systems may (should!! 😄 ) start doing this, so we can easily add them to the list.