### PR TITLE
CI: Add support for Python 3.12

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -42,6 +42,7 @@ jobs:
           - '3.9'
           - '3.10'
           - '3.11'
+          - '3.12'
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
~~Python 3.12 release candidates are available, and version 3.12 has been available in GitHub runners for almost a year:
	https://github.com/actions/setup-python/issues/514~~