### PR TITLE
Add forbid-in-block-sequences feature for detecting empty values in block sequences

### DIFF
--- a/tests/rules/test_empty_values.py
+++ b/tests/rules/test_empty_values.py
@@ -42,7 +42,8 @@ class EmptyValuesTestCase(RuleTestCase):
 
     def test_in_block_mappings_disabled(self):
         conf = ('empty-values: {forbid-in-block-mappings: false,\n'
-                '               forbid-in-flow-mappings: false}\n')
+                '               forbid-in-flow-mappings: false,\n'
+                '               forbid-in-block-sequences: false}\n')
         self.check('---\n'
                    'foo:\n', conf)
         self.check('---\n'
@@ -51,7 +52,8 @@ class EmptyValuesTestCase(RuleTestCase):
 
     def test_in_block_mappings_single_line(self):
         conf = ('empty-values: {forbid-in-block-mappings: true,\n'
-                '               forbid-in-flow-mappings: false}\n')
+                '               forbid-in-flow-mappings: false,\n'
+                '               forbid-in-block-sequences: false}\n')
         self.check('---\n'
                    'implicitly-null:\n', conf, problem1=(2, 17))
         self.check('---\n'
@@ -63,7 +65,8 @@ class EmptyValuesTestCase(RuleTestCase):
 
     def test_in_block_mappings_all_lines(self):
         conf = ('empty-values: {forbid-in-block-mappings: true,\n'
-                '               forbid-in-flow-mappings: false}\n')
+                '               forbid-in-flow-mappings: false,\n'
+                '               forbid-in-block-sequences: false}\n')
         self.check('---\n'
                    'foo:\n'
                    'bar:\n'
@@ -72,14 +75,16 @@ class EmptyValuesTestCase(RuleTestCase):
 
     def test_in_block_mappings_explicit_end_of_document(self):
         conf = ('empty-values: {forbid-in-block-mappings: true,\n'
-                '               forbid-in-flow-mappings: false}\n')
+                '               forbid-in-flow-mappings: false,\n'
+                '               forbid-in-block-sequences: false}\n')
         self.check('---\n'
                    'foo:\n'
                    '...\n', conf, problem1=(2, 5))
 
     def test_in_block_mappings_not_end_of_document(self):
         conf = ('empty-values: {forbid-in-block-mappings: true,\n'
-                '               forbid-in-flow-mappings: false}\n')
+                '               forbid-in-flow-mappings: false,\n'
+                '               forbid-in-block-sequences: false}\n')
         self.check('---\n'
                    'foo:\n'
                    'bar:\n'
@@ -87,7 +92,8 @@ class EmptyValuesTestCase(RuleTestCase):
 
     def test_in_block_mappings_different_level(self):
         conf = ('empty-values: {forbid-in-block-mappings: true,\n'
-                '               forbid-in-flow-mappings: false}\n')
+                '               forbid-in-flow-mappings: false,\n'
+                '               forbid-in-block-sequences: false}\n')
         self.check('---\n'
                    'foo:\n'
                    ' bar:\n'
@@ -95,7 +101,8 @@ class EmptyValuesTestCase(RuleTestCase):
 
     def test_in_block_mappings_empty_flow_mapping(self):
         conf = ('empty-values: {forbid-in-block-mappings: true,\n'
-                '               forbid-in-flow-mappings: false}\n'
+                '               forbid-in-flow-mappings: false,\n'
+                '               forbid-in-block-sequences: false}\n'
                 'braces: disable\n'
                 'commas: disable\n')
         self.check('---\n'
@@ -107,14 +114,16 @@ class EmptyValuesTestCase(RuleTestCase):
 
     def test_in_block_mappings_empty_block_sequence(self):
         conf = ('empty-values: {forbid-in-block-mappings: true,\n'
-                '               forbid-in-flow-mappings: false}\n')
+                '               forbid-in-flow-mappings: false,\n'
+                '               forbid-in-block-sequences: false}\n')
         self.check('---\n'
                    'foo:\n'
                    '  -\n', conf)
 
     def test_in_block_mappings_not_empty_or_explicit_null(self):
         conf = ('empty-values: {forbid-in-block-mappings: true,\n'
-                '               forbid-in-flow-mappings: false}\n')
+                '               forbid-in-flow-mappings: false,\n'
+                '               forbid-in-block-sequences: false}\n')
         self.check('---\n'
                    'foo:\n'
                    ' bar:\n'
@@ -137,7 +146,8 @@ class EmptyValuesTestCase(RuleTestCase):
 
     def test_in_block_mappings_various_explicit_null(self):
         conf = ('empty-values: {forbid-in-block-mappings: true,\n'
-                '               forbid-in-flow-mappings: false}\n')
+                '               forbid-in-flow-mappings: false,\n'
+                '               forbid-in-block-sequences: false}\n')
         self.check('---\n'
                    'null-alias: ~\n', conf)
         self.check('---\n'
@@ -147,7 +157,8 @@ class EmptyValuesTestCase(RuleTestCase):
 
     def test_in_block_mappings_comments(self):
         conf = ('empty-values: {forbid-in-block-mappings: true,\n'
-                '               forbid-in-flow-mappings: false}\n'
+                '               forbid-in-flow-mappings: false,\n'
+                '               forbid-in-block-sequences: false}\n'
                 'comments: disable\n')
         self.check('---\n'
                    'empty:  # comment\n'
@@ -158,7 +169,8 @@ class EmptyValuesTestCase(RuleTestCase):
 
     def test_in_flow_mappings_disabled(self):
         conf = ('empty-values: {forbid-in-block-mappings: false,\n'
-                '               forbid-in-flow-mappings: false}\n'
+                '               forbid-in-flow-mappings: false,\n'
+                '               forbid-in-block-sequences: false}\n'
                 'braces: disable\n'
                 'commas: disable\n')
         self.check('---\n'
@@ -175,7 +187,8 @@ class EmptyValuesTestCase(RuleTestCase):
 
     def test_in_flow_mappings_single_line(self):
         conf = ('empty-values: {forbid-in-block-mappings: false,\n'
-                '               forbid-in-flow-mappings: true}\n'
+                '               forbid-in-flow-mappings: true,\n'
+                '               forbid-in-block-sequences: false}\n'
                 'braces: disable\n'
                 'commas: disable\n')
         self.check('---\n'
@@ -201,7 +214,8 @@ class EmptyValuesTestCase(RuleTestCase):
 
     def test_in_flow_mappings_multi_line(self):
         conf = ('empty-values: {forbid-in-block-mappings: false,\n'
-                '               forbid-in-flow-mappings: true}\n'
+                '               forbid-in-flow-mappings: true,\n'
+                '               forbid-in-block-sequences: false}\n'
                 'braces: disable\n'
                 'commas: disable\n')
         self.check('---\n'
@@ -226,7 +240,8 @@ class EmptyValuesTestCase(RuleTestCase):
 
     def test_in_flow_mappings_various_explicit_null(self):
         conf = ('empty-values: {forbid-in-block-mappings: false,\n'
-                '               forbid-in-flow-mappings: true}\n'
+                '               forbid-in-flow-mappings: true,\n'
+                '               forbid-in-block-sequences: false}\n'
                 'braces: disable\n'
                 'commas: disable\n')
         self.check('---\n'
@@ -240,7 +255,8 @@ class EmptyValuesTestCase(RuleTestCase):
 
     def test_in_flow_mappings_comments(self):
         conf = ('empty-values: {forbid-in-block-mappings: false,\n'
-                '               forbid-in-flow-mappings: true}\n'
+                '               forbid-in-flow-mappings: true,\n'
+                '               forbid-in-block-sequences: false}\n'
                 'braces: disable\n'
                 'commas: disable\n'
                 'comments: disable\n')
@@ -259,12 +275,10 @@ class EmptyValuesTestCase(RuleTestCase):
                    problem2=(7, 9),
                    problem3=(10, 5))
 
-    def test_in_list_items_disabled(self):
+    def test_in_block_sequences_disabled(self):
         conf = ('empty-values: {forbid-in-block-mappings: false,\n'
                 '               forbid-in-flow-mappings: false,\n'
-                '               forbid-in-list-items: false}\n'
-                'braces: disable\n'
-                'commas: disable\n')
+                '               forbid-in-block-sequences: false}\n')
         self.check('---\n'
                    'foo:\n'
                    '  - bar\n'
@@ -273,12 +287,10 @@ class EmptyValuesTestCase(RuleTestCase):
                    'foo:\n'
                    '  -\n', conf)
 
-    def test_in_list_items_primative_item(self):
+    def test_in_block_sequences_primative_item(self):
         conf = ('empty-values: {forbid-in-block-mappings: false,\n'
                 '               forbid-in-flow-mappings: false,\n'
-                '               forbid-in-list-items: true}\n'
-                'braces: disable\n'
-                'commas: disable\n')
+                '               forbid-in-block-sequences: true}\n')
         self.check('---\n'
                    'foo:\n'
                    '  -\n', conf,
@@ -296,14 +308,49 @@ class EmptyValuesTestCase(RuleTestCase):
                    problem=(5, 4))
         self.check('---\n'
                    'foo:\n'
-                   '  - null\n', conf)
+                   '  - true\n', conf)
 
-    def test_in_list_items_various_explicit_null(self):
+    def test_in_block_sequences_complex_objects(self):
         conf = ('empty-values: {forbid-in-block-mappings: false,\n'
                 '               forbid-in-flow-mappings: false,\n'
-                '               forbid-in-list-items: true}\n'
-                'braces: disable\n'
-                'commas: disable\n')
+                '               forbid-in-block-sequences: true}\n')
+        self.check('---\n'
+                   'foo:\n'
+                   '  - a: 1\n', conf)
+        self.check('---\n'
+                   'foo:\n'
+                   '  - a: 1\n'
+                   '  -\n', conf,
+                   problem=(4, 4))
+        self.check('---\n'
+                   'foo:\n'
+                   '  - a: 1\n'
+                   '    b: 2\n'
+                   '  -\n', conf,
+                   problem=(5, 4))
+        self.check('---\n'
+                   'foo:\n'
+                   '  - a: 1\n'
+                   '  - b: 2\n'
+                   '  -\n', conf,
+                   problem=(5, 4))
+        self.check('---\n'
+                   'foo:\n'
+                   '  - - a\n'
+                   '    - b: 2\n'
+                   '    -\n', conf,
+                   problem=(5, 6))
+        self.check('---\n'
+                   'foo:\n'
+                   '  - - a\n'
+                   '    - b: 2\n'
+                   '  -\n', conf,
+                   problem=(5, 4))
+
+    def test_in_block_sequences_various_explicit_null(self):
+        conf = ('empty-values: {forbid-in-block-mappings: false,\n'
+                '               forbid-in-flow-mappings: false,\n'
+                '               forbid-in-block-sequences: true}\n')
         self.check('---\n'
                    'foo:\n'
                    '  - null\n', conf)
@@ -311,7 +358,11 @@ class EmptyValuesTestCase(RuleTestCase):
                    '- null\n', conf)
         self.check('---\n'
                    'foo:\n'
-                   '  - bar: null\n', conf)
+                   '  - bar: null\n'
+                   '  - null\n', conf)
         self.check('---\n'
                    '- null\n'
                    '- null\n', conf)
+        self.check('---\n'
+                   '- - null\n'
+                   '  - null\n', conf)

--- a/tests/rules/test_empty_values.py
+++ b/tests/rules/test_empty_values.py
@@ -258,3 +258,60 @@ class EmptyValuesTestCase(RuleTestCase):
                    problem1=(4, 7),
                    problem2=(7, 9),
                    problem3=(10, 5))
+
+    def test_in_list_items_disabled(self):
+        conf = ('empty-values: {forbid-in-block-mappings: false,\n'
+                '               forbid-in-flow-mappings: false,\n'
+                '               forbid-in-list-items: false}\n'
+                'braces: disable\n'
+                'commas: disable\n')
+        self.check('---\n'
+                   'foo:\n'
+                   '  - bar\n'
+                   '  -\n', conf)
+        self.check('---\n'
+                   'foo:\n'
+                   '  -\n', conf)
+
+    def test_in_list_items_primative_item(self):
+        conf = ('empty-values: {forbid-in-block-mappings: false,\n'
+                '               forbid-in-flow-mappings: false,\n'
+                '               forbid-in-list-items: true}\n'
+                'braces: disable\n'
+                'commas: disable\n')
+        self.check('---\n'
+                   'foo:\n'
+                   '  -\n', conf,
+                   problem=(3, 4))
+        self.check('---\n'
+                   'foo:\n'
+                   '  - bar\n'
+                   '  -\n', conf,
+                   problem=(4, 4))
+        self.check('---\n'
+                   'foo:\n'
+                   '  - 1\n'
+                   '  - 2\n'
+                   '  -\n', conf,
+                   problem=(5, 4))
+        self.check('---\n'
+                   'foo:\n'
+                   '  - null\n', conf)
+
+    def test_in_list_items_various_explicit_null(self):
+        conf = ('empty-values: {forbid-in-block-mappings: false,\n'
+                '               forbid-in-flow-mappings: false,\n'
+                '               forbid-in-list-items: true}\n'
+                'braces: disable\n'
+                'commas: disable\n')
+        self.check('---\n'
+                   'foo:\n'
+                   '  - null\n', conf)
+        self.check('---\n'
+                   '- null\n', conf)
+        self.check('---\n'
+                   'foo:\n'
+                   '  - bar: null\n', conf)
+        self.check('---\n'
+                   '- null\n'
+                   '- null\n', conf)

--- a/yamllint/rules/empty_values.py
+++ b/yamllint/rules/empty_values.py
@@ -81,6 +81,7 @@ Use this rule to prevent nodes with empty content, that implicitly result in
 
     some-sequence:
       - string item
+
    ::
 
     some-sequence:
@@ -91,6 +92,7 @@ Use this rule to prevent nodes with empty content, that implicitly result in
 
     some-sequence:
       -
+
    ::
 
     some-sequence:

--- a/yamllint/rules/empty_values.py
+++ b/yamllint/rules/empty_values.py
@@ -82,9 +82,11 @@ from yamllint.linter import LintProblem
 ID = 'empty-values'
 TYPE = 'token'
 CONF = {'forbid-in-block-mappings': bool,
-        'forbid-in-flow-mappings': bool}
+        'forbid-in-flow-mappings': bool,
+        'forbid-in-list-items': bool}
 DEFAULT = {'forbid-in-block-mappings': True,
-           'forbid-in-flow-mappings': True}
+           'forbid-in-flow-mappings': True,
+           'forbid-in-list-items': False}
 
 
 def check(conf, token, prev, next, nextnext, context):
@@ -102,3 +104,10 @@ def check(conf, token, prev, next, nextnext, context):
             yield LintProblem(token.start_mark.line + 1,
                               token.end_mark.column + 1,
                               'empty value in flow mapping')
+
+    if conf['forbid-in-list-items']:
+        if isinstance(token, yaml.BlockEntryToken) and isinstance(next, (
+                yaml.KeyToken, yaml.BlockEndToken, yaml.BlockEntryToken)):
+            yield LintProblem(token.start_mark.line + 1,
+                              token.end_mark.column + 1,
+                              'empty value in list items')

--- a/yamllint/rules/empty_values.py
+++ b/yamllint/rules/empty_values.py
@@ -21,6 +21,7 @@ Use this rule to prevent nodes with empty content, that implicitly result in
 
 * Use ``forbid-in-block-mappings`` to prevent empty values in block mappings.
 * Use ``forbid-in-flow-mappings`` to prevent empty values in flow mappings.
+* Use ``forbid-in-list-items`` to prevent empty values in lists.
 
 .. rubric:: Default values (when enabled)
 
@@ -30,6 +31,7 @@ Use this rule to prevent nodes with empty content, that implicitly result in
    empty-values:
      forbid-in-block-mappings: true
      forbid-in-flow-mappings: true
+     forbid-in-list-items: false
 
 .. rubric:: Examples
 
@@ -71,6 +73,26 @@ Use this rule to prevent nodes with empty content, that implicitly result in
    ::
 
     {a: 1, b:, c: 3}
+
+#. With ``empty-values: {forbid-in-list-items: true}``
+
+   the following code snippet would **PASS**:
+   ::
+
+    some-list:
+      - string item
+
+   the following code snippets would **FAIL**:
+   ::
+
+    some-list:
+      -
+
+   ::
+
+    some-list:
+      - string item
+      -
 
 """
 

--- a/yamllint/rules/empty_values.py
+++ b/yamllint/rules/empty_values.py
@@ -21,7 +21,7 @@ Use this rule to prevent nodes with empty content, that implicitly result in
 
 * Use ``forbid-in-block-mappings`` to prevent empty values in block mappings.
 * Use ``forbid-in-flow-mappings`` to prevent empty values in flow mappings.
-* Use ``forbid-in-list-items`` to prevent empty values in lists.
+* Use ``forbid-in-block-sequences`` to prevent empty values in block sequences.
 
 .. rubric:: Default values (when enabled)
 
@@ -31,7 +31,7 @@ Use this rule to prevent nodes with empty content, that implicitly result in
    empty-values:
      forbid-in-block-mappings: true
      forbid-in-flow-mappings: true
-     forbid-in-list-items: false
+     forbid-in-block-sequences: true
 
 .. rubric:: Examples
 
@@ -74,23 +74,26 @@ Use this rule to prevent nodes with empty content, that implicitly result in
 
     {a: 1, b:, c: 3}
 
-#. With ``empty-values: {forbid-in-list-items: true}``
+#. With ``empty-values: {forbid-in-block-sequences: true}``
 
    the following code snippet would **PASS**:
    ::
 
-    some-list:
+    some-sequence:
       - string item
+   ::
+
+    some-sequence:
+      - null
 
    the following code snippets would **FAIL**:
    ::
 
-    some-list:
+    some-sequence:
       -
-
    ::
 
-    some-list:
+    some-sequence:
       - string item
       -
 
@@ -105,10 +108,10 @@ ID = 'empty-values'
 TYPE = 'token'
 CONF = {'forbid-in-block-mappings': bool,
         'forbid-in-flow-mappings': bool,
-        'forbid-in-list-items': bool}
+        'forbid-in-block-sequences': bool}
 DEFAULT = {'forbid-in-block-mappings': True,
            'forbid-in-flow-mappings': True,
-           'forbid-in-list-items': False}
+           'forbid-in-block-sequences': True}
 
 
 def check(conf, token, prev, next, nextnext, context):
@@ -127,9 +130,9 @@ def check(conf, token, prev, next, nextnext, context):
                               token.end_mark.column + 1,
                               'empty value in flow mapping')
 
-    if conf['forbid-in-list-items']:
+    if conf['forbid-in-block-sequences']:
         if isinstance(token, yaml.BlockEntryToken) and isinstance(next, (
                 yaml.KeyToken, yaml.BlockEndToken, yaml.BlockEntryToken)):
             yield LintProblem(token.start_mark.line + 1,
                               token.end_mark.column + 1,
-                              'empty value in list items')
+                              'empty value in block sequence')


### PR DESCRIPTION
feat: Add `forbid-in-list-items` feature to detect empty values in lists

This commit introduces a new feature, `forbid-in-list-items`, which allows users to check for empty values within lists. The default behavior is set to `false`, but it can be activated by setting the `forbid-in-list-items` configuration variable to `true`.

The `check` function has been updated to handle this feature, and it will now identify and report empty values within list items when `forbid-in-list-items` is enabled.

This enhancement provides users with more control and flexibility when using the linter for YAML files.
