### PR TITLE
build: Migrate to use .readthedocs.yaml for docs generation

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,8 @@
+---
+version: 2
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+sphinx:
+  configuration: docs/conf.py


### PR DESCRIPTION
As explained on https://readthedocs.org/projects/yamllint/:
> Your builds will stop working soon!
> Configuration files will soon be required by projects, and will no
> longer be optional. Read our blog post to create one and ensure your
> project continues building successfully.

https://blog.readthedocs.com/migrate-configuration-v2/