### PR TITLE
tests: Remove test skipping for Python < 3.7

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -116,8 +116,6 @@ class CommandLineTestCase(unittest.TestCase):
 
         shutil.rmtree(cls.wd)
 
-    @unittest.skipIf(not utf8_available() and sys.version_info < (3, 7),
-                     'UTF-8 paths not supported')
     def test_find_files_recursively(self):
         conf = config.YamlLintConfig('extends: default')
         self.assertEqual(


### PR DESCRIPTION
Yamllint dropped support for Python 3.6 in september 2022.