### PR TITLE
Environment variable-related test fixes

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -328,7 +328,6 @@ class CommandLineTestCase(unittest.TestCase):
             cli.run(('-c', f.name, os.path.join(self.wd, 'a.yaml')))
         self.assertEqual(ctx.returncode, 1)
 
-    @unittest.skipIf(os.environ.get('GITHUB_RUN_ID'), '$HOME not overridable')
     def test_run_with_user_global_config_file(self):
         home = os.path.join(self.wd, 'fake-home')
         dir = os.path.join(home, '.config', 'yamllint')

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -315,7 +315,7 @@ class CommandLineTestCase(unittest.TestCase):
         os.makedirs(dir)
         config = os.path.join(dir, 'config')
 
-        self.addCleanup(os.environ.update, HOME=os.environ['HOME'])
+        self.addCleanup(os.environ.__delitem__, 'HOME')
         os.environ['HOME'] = home
 
         with open(config, 'w') as f:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -66,6 +66,26 @@ def utf8_available():
         return False
 
 
+def setUpModule():
+    # yamllint uses these environment variables to find a config file.
+    env_vars_that_could_interfere = (
+        'YAMLLINT_CONFIG_FILE',
+        'XDG_CONFIG_HOME',
+        # These variables are used to determine where the user’s home
+        # directory is. See
+        # https://docs.python.org/3/library/os.path.html#os.path.expanduser
+        'HOME',
+        'USERPROFILE',
+        'HOMEPATH',
+        'HOMEDRIVE'
+    )
+    for name in env_vars_that_could_interfere:
+        try:
+            del os.environ[name]
+        except KeyError:
+            pass
+
+
 class CommandLineTestCase(unittest.TestCase):
     @classmethod
     def setUpClass(cls):


### PR DESCRIPTION
See the individual commits for details.

While I was working on implementing what was discussed [here](https://github.com/adrienverge/yamllint/issues/621#issuecomment-1872579265), I realized that there were other edge cases where environment variables could cause problems. For example, running `YAMLLINT_CONFIG_FILE=/random/binary/file python -m pytest discover` caused a bunch of new test failures. I decided to implement a more robust solution that fixes the problem for more than just `test_run_with_user_global_config_file`.

Fixes #605. Fixes #621.
