### PR TITLE
cli: remove format() left over in f63e56f

### DIFF
--- a/yamllint/cli.py
+++ b/yamllint/cli.py
@@ -79,9 +79,9 @@ class Format:
 
     @staticmethod
     def github(problem, filename):
-        line = f'::{problem.level} file={format(filename)},' \
-               f'line={format(problem.line)},col={format(problem.column)}' \
-               f'::{format(problem.line)}:{format(problem.column)} '
+        line = f'::{problem.level} file={filename},' \
+               f'line={problem.line},col={problem.column}' \
+               f'::{problem.line}:{problem.column} '
         if problem.rule:
             line += f'[{problem.rule}] '
         line += problem.desc


### PR DESCRIPTION
See #600 / f63e56f.
- The format() call was missing in the first place for `filename`.
- Other format() calls are obviously useless now that f-strings perform string interpolation.