### PR TITLE
style: apply ruff suggestion

### DIFF
--- a/tests/common.py
+++ b/tests/common.py
@@ -62,7 +62,7 @@ def build_temp_workspace(files):
         if not os.path.exists(os.path.dirname(path)):
             os.makedirs(os.path.dirname(path))
 
-        if type(content) is list:
+        if isinstance(content, list):
             os.mkdir(path)
         else:
             mode = 'wb' if isinstance(content, bytes) else 'w'

--- a/yamllint/config.py
+++ b/yamllint/config.py
@@ -205,7 +205,7 @@ def validate_rule_conf(rule, conf):
             # Example: CONF = {option: ['flag1', 'flag2', int]}
             #          → {option: [flag1]}      → {option: [42, flag1, flag2]}
             elif isinstance(options[optkey], list):
-                if (type(conf[optkey]) is not list or
+                if (not isinstance(conf[optkey], list) or
                         any(flag not in options[optkey] and
                             type(flag) not in options[optkey]
                             for flag in conf[optkey])):


### PR DESCRIPTION
Fixes the only error reported by [ruff](https://astral.sh/ruff) using default settings:
```
E721 Do not compare types, use `isinstance()`
```