### PR TITLE
build: main() not required any more

### DIFF
--- a/yamllint/__main__.py
+++ b/yamllint/__main__.py
@@ -1,4 +1,0 @@
-from yamllint.cli import run
-
-if __name__ == '__main__':
-    run()


### PR DESCRIPTION
Since adding `"yamllint.cli:run"`, we don't need a `main()` function.