### PR TITLE
style: apply flake8-copyright rules

### DIFF
--- a/yamllint/__main__.py
+++ b/yamllint/__main__.py
@@ -1,3 +1,18 @@
+# Copyright (C) 2016 Adrien Vergé
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 from yamllint.cli import run
 
 if __name__ == '__main__':


### PR DESCRIPTION
```
CPY001 Missing copyright notice at top of file
```

Do not apply this rule to empty files:
* `tests/rules/__init__.py`

and to files generated by tools:
* `docs/conf.py`