### PR TITLE
skip ignored files at discovery

### DIFF
--- a/yamllint/cli.py
+++ b/yamllint/cli.py
@@ -30,7 +30,7 @@ def find_files_recursively(items, conf):
             for root, _dirnames, filenames in os.walk(item):
                 for f in filenames:
                     filepath = os.path.join(root, f)
-                    if conf.is_yaml_file(filepath):
+                    if conf.is_yaml_file(filepath) and not conf.is_file_ignored(filepath):
                         yield filepath
         else:
             yield item


### PR DESCRIPTION
ignored files should be skipped early on to prevent other issues such as tripping on intentionally ignored broken symlinks.

There are many reasons that a file is ignored, one of those reasons is that it is a symlink which for valid reasons is broken. Without this change, this results in an `[Errno 2] No such file or directory:` error which can cause CI/CD to fail. 

There likely is efficiencies by skipping to read in the skipped files at startup, but that is not the point of this PR.