### PR TITLE
Revert replacement of flake8 with ruff

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,4 @@
+[flake8]
+import-order-style = pep8
+application-import-names = yamllint
+ignore = W503,W504

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,9 +21,9 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
       - run:
-          pip install ruff sphinx rstcheck[sphinx] doc8
+          pip install flake8 flake8-import-order sphinx rstcheck[sphinx] doc8
       - run: pip install .
-      - run: ruff .
+      - run: flake8 .
       - run: doc8 $(git ls-files '*.rst')
       - run: rstcheck --ignore-directives automodule $(git ls-files '*.rst')
       - run: yamllint --strict $(git ls-files '*.yaml' '*.yml')

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -1,6 +1,0 @@
-[lint]
-extend-select = ["B", "I", "PGH", "TRY", "UP"]
-ignore = ["TRY003"]
-
-[lint.isort]
-known-third-party = ["tests"]

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -23,7 +23,7 @@ Pull Request Process
 
    .. code:: bash
 
-    ruff .
+    flake8 .
 
    If you added/modified documentation:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,8 +26,9 @@ dynamic = ["version"]
 [project.optional-dependencies]
 dev = [
     "doc8",
+    "flake8",
+    "flake8-import-order",
     "rstcheck[sphinx]",
-    "ruff",
     "sphinx",
 ]
 

--- a/tests/rules/test_indentation.py
+++ b/tests/rules/test_indentation.py
@@ -192,7 +192,7 @@ class IndentationStackTestCase(RuleTestCase):
             'BMapStart B_MAP:0 KEY:0 VAL:2 B_SEQ:0 B_ENT:2 B_MAP:2\n'
             '      Key B_MAP:0 KEY:0 VAL:2 B_SEQ:0 B_ENT:2 B_MAP:2 KEY:2\n'
             '   Scalar B_MAP:0 KEY:0 VAL:2 B_SEQ:0 B_ENT:2 B_MAP:2 KEY:2\n'
-            '    Value B_MAP:0 KEY:0 VAL:2 B_SEQ:0 B_ENT:2 B_MAP:2 KEY:2 VAL:4\n'
+            '    Value B_MAP:0 KEY:0 VAL:2 B_SEQ:0 B_ENT:2 B_MAP:2 KEY:2 VAL:4\n'  # noqa: E501
             '   Scalar B_MAP:0 KEY:0 VAL:2 B_SEQ:0 B_ENT:2 B_MAP:2\n'
             '     BEnd B_MAP:0\n'
             # missing BEnd here

--- a/tests/test_spec_examples.py
+++ b/tests/test_spec_examples.py
@@ -42,6 +42,7 @@ from tests.common import RuleTestCase
 #                       encoding='utf-8') as g:
 #                 g.write(text)
 
+
 class SpecificationTestCase(RuleTestCase):
     rule_id = None
 


### PR DESCRIPTION
* Start with reverting parts of commit 26be794 in #629 related to config and CI jobs.
* Undo ruff changes that conflict with flake8

Fixes https://github.com/adrienverge/yamllint/issues/628#issuecomment-1920820663.