### PR TITLE
build: Restore official Read the Docs theme

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,7 +21,8 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
       - run:
-          pip install flake8 flake8-import-order sphinx rstcheck[sphinx] doc8
+          pip install flake8 flake8-import-order sphinx sphinx_rtd_theme
+          rstcheck[sphinx] doc8
       - run: pip install .
       - run: flake8 .
       - run: doc8 $(git ls-files '*.rst')

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -3,6 +3,9 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.11"
+    python: "3.12"
 sphinx:
   configuration: docs/conf.py
+python:
+  install:
+    - requirements: docs/requirements.txt

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -6,12 +6,12 @@ import sys
 from unittest.mock import MagicMock
 
 sys.path.insert(0, os.path.abspath('..'))
-
 from yamllint import __copyright__, APP_NAME, APP_VERSION  # noqa: I001, E402
 
 # -- General configuration ------------------------------------------------
 
 extensions = [
+    'sphinx_rtd_theme',
     'sphinx.ext.autodoc',
 ]
 
@@ -29,7 +29,7 @@ pygments_style = 'sphinx'
 
 # -- Options for HTML output ----------------------------------------------
 
-html_theme = 'default'
+html_theme = 'sphinx_rtd_theme'
 
 htmlhelp_basename = 'yamllintdoc'
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,1 @@
+sphinx-rtd-theme >=2.0.0


### PR DESCRIPTION
https://yamllint.readthedocs.io/en/v1.34.0/ was rendered differently than previous versions, very probably due to change of commit ca7f8b9 "Migrate to use .readthedocs.yaml for docs generation".

Let's restore the `sphinx_rtd_theme` theme.