### PR TITLE
cli: Cleanly skip broken symlinks that are ignored

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -23,36 +23,9 @@ import tempfile
 import unittest
 from io import StringIO
 
-from tests.common import build_temp_workspace, temp_workspace
+from tests.common import build_temp_workspace, RunContext, temp_workspace
 
 from yamllint import cli, config
-
-
-class RunContext:
-    """Context manager for ``cli.run()`` to capture exit code and streams."""
-
-    def __init__(self, case):
-        self.stdout = self.stderr = None
-        self._raises_ctx = case.assertRaises(SystemExit)
-
-    def __enter__(self):
-        self._raises_ctx.__enter__()
-        self.old_sys_stdout = sys.stdout
-        self.old_sys_stderr = sys.stderr
-        sys.stdout = self.outstream = StringIO()
-        sys.stderr = self.errstream = StringIO()
-        return self
-
-    def __exit__(self, *exc_info):
-        self.stdout = self.outstream.getvalue()
-        self.stderr = self.errstream.getvalue()
-        sys.stdout = self.old_sys_stdout
-        sys.stderr = self.old_sys_stderr
-        return self._raises_ctx.__exit__(*exc_info)
-
-    @property
-    def returncode(self):
-        return self._raises_ctx.exception.code
 
 
 # Check system's UTF-8 availability
@@ -112,6 +85,9 @@ class CommandLineTestCase(unittest.TestCase):
                                                        'key: other value\n',
             # empty dir
             'empty-dir': [],
+            # symbolic link
+            'symlinks/file-without-yaml-extension': '42\n',
+            'symlinks/link.yaml': 'symlink://file-without-yaml-extension',
             # non-YAML file
             'no-yaml.json': '---\n'
                             'key: value\n',
@@ -152,6 +128,7 @@ class CommandLineTestCase(unittest.TestCase):
              os.path.join(self.wd, 's/s/s/s/s/s/s/s/s/s/s/s/s/s/s/file.yaml'),
              os.path.join(self.wd, 'sub/directory.yaml/empty.yml'),
              os.path.join(self.wd, 'sub/ok.yaml'),
+             os.path.join(self.wd, 'symlinks/link.yaml'),
              os.path.join(self.wd, 'warn.yaml')],
         )
 
@@ -189,6 +166,7 @@ class CommandLineTestCase(unittest.TestCase):
              os.path.join(self.wd, 'en.yaml'),
              os.path.join(self.wd, 's/s/s/s/s/s/s/s/s/s/s/s/s/s/s/file.yaml'),
              os.path.join(self.wd, 'sub/ok.yaml'),
+             os.path.join(self.wd, 'symlinks/link.yaml'),
              os.path.join(self.wd, 'warn.yaml')]
         )
 
@@ -226,6 +204,8 @@ class CommandLineTestCase(unittest.TestCase):
              os.path.join(self.wd, 'sub/directory.yaml/empty.yml'),
              os.path.join(self.wd, 'sub/directory.yaml/not-yaml.txt'),
              os.path.join(self.wd, 'sub/ok.yaml'),
+             os.path.join(self.wd, 'symlinks/file-without-yaml-extension'),
+             os.path.join(self.wd, 'symlinks/link.yaml'),
              os.path.join(self.wd, 'warn.yaml')]
         )
 
@@ -247,6 +227,8 @@ class CommandLineTestCase(unittest.TestCase):
              os.path.join(self.wd, 'sub/directory.yaml/empty.yml'),
              os.path.join(self.wd, 'sub/directory.yaml/not-yaml.txt'),
              os.path.join(self.wd, 'sub/ok.yaml'),
+             os.path.join(self.wd, 'symlinks/file-without-yaml-extension'),
+             os.path.join(self.wd, 'symlinks/link.yaml'),
              os.path.join(self.wd, 'warn.yaml')]
         )
 
@@ -711,6 +693,7 @@ class CommandLineTestCase(unittest.TestCase):
              os.path.join(self.wd, 's/s/s/s/s/s/s/s/s/s/s/s/s/s/s/file.yaml'),
              os.path.join(self.wd, 'sub/directory.yaml/empty.yml'),
              os.path.join(self.wd, 'sub/ok.yaml'),
+             os.path.join(self.wd, 'symlinks/link.yaml'),
              os.path.join(self.wd, 'warn.yaml')]
         )
 
@@ -727,6 +710,7 @@ class CommandLineTestCase(unittest.TestCase):
              os.path.join(self.wd, 's/s/s/s/s/s/s/s/s/s/s/s/s/s/s/file.yaml'),
              os.path.join(self.wd, 'sub/directory.yaml/not-yaml.txt'),
              os.path.join(self.wd, 'sub/ok.yaml'),
+             os.path.join(self.wd, 'symlinks/link.yaml'),
              os.path.join(self.wd, 'warn.yaml')]
         )
 

--- a/yamllint/cli.py
+++ b/yamllint/cli.py
@@ -30,7 +30,8 @@ def find_files_recursively(items, conf):
             for root, _dirnames, filenames in os.walk(item):
                 for f in filenames:
                     filepath = os.path.join(root, f)
-                    if conf.is_yaml_file(filepath):
+                    if (conf.is_yaml_file(filepath) and
+                            not conf.is_file_ignored(filepath)):
                         yield filepath
         else:
             yield item
@@ -209,8 +210,7 @@ def run(argv=None):
 
     if args.list_files:
         for file in find_files_recursively(args.files, conf):
-            if not conf.is_file_ignored(file):
-                print(file)
+            print(file)
         sys.exit(0)
 
     max_level = 0

--- a/yamllint/linter.py
+++ b/yamllint/linter.py
@@ -222,9 +222,6 @@ def run(input, conf, filepath=None):
     :param input: buffer, string or stream to read from
     :param conf: yamllint configuration object
     """
-    if filepath is not None and conf.is_file_ignored(filepath):
-        return ()
-
     if isinstance(input, (bytes, str)):
         return _run(input, conf, filepath)
     elif isinstance(input, io.IOBase):


### PR DESCRIPTION
Before this commit, yamllint would output "[Errno 2] No such file or directory" when running on a directory which contained a broken symbolic link, even if the file is set to be ignored in yamllint configuration.

This commit fixes that, and adds corresponding tests.

As a side effect this changes `yamllint.linter.run(stream, config)`, so tools that would use this API need to filter ignored files beforehand.

Fixes https://github.com/adrienverge/yamllint/issues/399