### PR TITLE
cli: Restore ignoration of files passed as command-line arguments

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -714,6 +714,25 @@ class CommandLineTestCase(unittest.TestCase):
              os.path.join(self.wd, 'warn.yaml')]
         )
 
+        config = 'ignore: ["*.yaml", "*.yml", "!a.yaml"]'
+        with RunContext(self) as ctx:
+            cli.run(('--list-files', '-d', config, self.wd))
+        self.assertEqual(ctx.returncode, 0)
+        self.assertEqual(
+            sorted(ctx.stdout.splitlines()),
+            [os.path.join(self.wd, 'a.yaml')]
+        )
+        with RunContext(self) as ctx:
+            cli.run(('--list-files', '-d', config,
+                     os.path.join(self.wd, 'a.yaml'),
+                     os.path.join(self.wd, 'en.yaml'),
+                     os.path.join(self.wd, 'c.yaml')))
+        self.assertEqual(ctx.returncode, 0)
+        self.assertEqual(
+            sorted(ctx.stdout.splitlines()),
+            [os.path.join(self.wd, 'a.yaml')]
+        )
+
 
 class CommandLineConfigTestCase(unittest.TestCase):
     def test_config_file(self):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -803,3 +803,20 @@ class IgnoreConfigTestCase(unittest.TestCase):
 
         os.chdir(backup_wd)
         shutil.rmtree(wd)
+
+    def test_run_with_ignore_on_ignored_file(self):
+        with open(os.path.join(self.wd, '.yamllint'), 'w') as f:
+            f.write('ignore: file.dont-lint-me.yaml\n'
+                    'rules:\n'
+                    '  trailing-spaces: enable\n'
+                    '  key-duplicates:\n'
+                    '    ignore: file-at-root.yaml\n')
+
+        sys.stdout = StringIO()
+        with self.assertRaises(SystemExit):
+            cli.run(('-f', 'parsable', 'file.dont-lint-me.yaml',
+                     'file-at-root.yaml'))
+        self.assertEqual(
+            sys.stdout.getvalue().strip(),
+            'file-at-root.yaml:4:17: [error] trailing spaces (trailing-spaces)'
+        )

--- a/yamllint/cli.py
+++ b/yamllint/cli.py
@@ -210,7 +210,8 @@ def run(argv=None):
 
     if args.list_files:
         for file in find_files_recursively(args.files, conf):
-            print(file)
+            if not conf.is_file_ignored(file):
+                print(file)
         sys.exit(0)
 
     max_level = 0

--- a/yamllint/linter.py
+++ b/yamllint/linter.py
@@ -222,6 +222,9 @@ def run(input, conf, filepath=None):
     :param input: buffer, string or stream to read from
     :param conf: yamllint configuration object
     """
+    if filepath is not None and conf.is_file_ignored(filepath):
+        return ()
+
     if isinstance(input, (bytes, str)):
         return _run(input, conf, filepath)
     elif isinstance(input, io.IOBase):


### PR DESCRIPTION
Commit 2344380 "Cleanly skip broken symlinks that are ignored" fixed a problem on symbolic links but also introduced a change on how ignored files should be treated, depending on whether they're explicitely passed as command-line arguments or not [^1].

This change is annoying for users that dynamically build the list of files to pass as arguments, e.g. [^2]:

    find -name '*\.yaml' | xargs yamllint

The present commit adds unit tests for `yamllint [FILES]...` and `yamllint --list-files [FILES]...`, that passed with previous version 1.34.0, and restore the behavior of this version.

As a result it also reverts the API change of commit 2344380 on `yamllint.linter.run(stream, config)`.

[^1]: https://github.com/adrienverge/yamllint/issues/657#issuecomment-1948009315
[^2]: https://github.com/adrienverge/yamllint/issues/657#issuecomment-1948093680