### PR TITLE
Add JSON output format for output

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -619,6 +619,23 @@ class CommandLineTestCase(unittest.TestCase):
         self.assertEqual(
             (ctx.returncode, ctx.stdout, ctx.stderr), (1, expected_out, ''))
 
+    def test_run_format_json(self):
+        path = os.path.join(self.wd, 'a.yaml')
+
+        with RunContext(self) as ctx:
+            cli.run((path, '--format', 'json'))
+        expected_out = (
+            '[\n  '
+            '{"file": "' + str(path) + '", "level": "error", "line": 2, '
+            '"column": 4, "description": "trailing spaces", '
+            '"rule": "trailing-spaces"},\n  '
+            '{"file": "' + str(path) + '", "level": "error", "line": 3, '
+            '"column": 4, "description": "no new line character at the end '
+            'of file", "rule": '
+            '"new-line-at-end-of-file"}\n]\n')
+        self.assertEqual(
+            (ctx.returncode, ctx.stdout, ctx.stderr), (1, expected_out, ''))
+
     def test_run_read_from_stdin(self):
         # prepares stdin with an invalid yaml string so that we can check
         # for its specific error, and be assured that stdin was read


### PR DESCRIPTION
This introduces JSON output format. I based this MR on one that was existing from a few years back under the label, #68 

It follows the same pattern, but rather than exposing some extra keys that suited a particular use case, it prints the fields out as they appear in the LintProblem class with the filepath added in to each record.

