### PR TITLE
docs: Import 'yamllint.config' rather than 'yamllint'

### DIFF
--- a/docs/development.rst
+++ b/docs/development.rst
@@ -8,7 +8,8 @@ Basic example of running the linter from Python:
 
 .. code-block:: python
 
-   import yamllint
+   import yamllint.config
+   import yamllint.linter
 
    yaml_config = yamllint.config.YamlLintConfig("extends: default")
    for p in yamllint.linter.run(open("example.yaml", "r"), yaml_config):


### PR DESCRIPTION
Since yamllint version 0.5.2 (in 2016, just after yamllint was created) this example in documentation doesn't work. Indeed, commit dbbecb5 (which aimed to solve another problem) removed the ability to import yamllint submodules directly.

This commit makes it clearer inside documentation.

Fixes https://github.com/adrienverge/yamllint/issues/698