### PR TITLE
fix: ignore-from-file relative to config file

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -121,72 +121,78 @@ class SimpleConfigTestCase(unittest.TestCase):
         self.assertEqual(c.rules['hyphens'], False)
 
     def test_validate_rule_conf(self):
+        c = config.YamlLintConfig('rules:\n'
+                                  '  indentation:\n'
+                                  '    spaces: 2\n'
+                                  '    indent-sequences: yes\n'
+                                  '    check-multi-line-strings: false\n')
+
         class Rule:
             ID = 'fake'
 
-        self.assertFalse(config.validate_rule_conf(Rule, False))
-        self.assertEqual(config.validate_rule_conf(Rule, {}),
+        self.assertFalse(c.validate_rule_conf(Rule, False))
+        self.assertEqual(c.validate_rule_conf(Rule, {}),
                          {'level': 'error'})
 
-        config.validate_rule_conf(Rule, {'level': 'error'})
-        config.validate_rule_conf(Rule, {'level': 'warning'})
+        c.validate_rule_conf(Rule, {'level': 'error'})
+        c.validate_rule_conf(Rule, {'level': 'warning'})
         self.assertRaises(config.YamlLintConfigError,
-                          config.validate_rule_conf, Rule, {'level': 'warn'})
+                          c.validate_rule_conf, Rule, {'level': 'warn'})
 
         Rule.CONF = {'length': int}
         Rule.DEFAULT = {'length': 80}
-        config.validate_rule_conf(Rule, {'length': 8})
-        config.validate_rule_conf(Rule, {})
+        c.validate_rule_conf(Rule, {'length': 8})
+        c.validate_rule_conf(Rule, {})
         self.assertRaises(config.YamlLintConfigError,
-                          config.validate_rule_conf, Rule, {'height': 8})
+                          c.validate_rule_conf, Rule, {'height': 8})
 
         Rule.CONF = {'a': bool, 'b': int}
         Rule.DEFAULT = {'a': True, 'b': -42}
-        config.validate_rule_conf(Rule, {'a': True, 'b': 0})
-        config.validate_rule_conf(Rule, {'a': True})
-        config.validate_rule_conf(Rule, {'b': 0})
+        c.validate_rule_conf(Rule, {'a': True, 'b': 0})
+        c.validate_rule_conf(Rule, {'a': True})
+        c.validate_rule_conf(Rule, {'b': 0})
         self.assertRaises(config.YamlLintConfigError,
-                          config.validate_rule_conf, Rule, {'a': 1, 'b': 0})
+                          c.validate_rule_conf, Rule, {'a': 1, 'b': 0})
 
         Rule.CONF = {'choice': (True, 88, 'str')}
         Rule.DEFAULT = {'choice': 88}
-        config.validate_rule_conf(Rule, {'choice': True})
-        config.validate_rule_conf(Rule, {'choice': 88})
-        config.validate_rule_conf(Rule, {'choice': 'str'})
+        c.validate_rule_conf(Rule, {'choice': True})
+        c.validate_rule_conf(Rule, {'choice': 88})
+        c.validate_rule_conf(Rule, {'choice': 'str'})
         self.assertRaises(config.YamlLintConfigError,
-                          config.validate_rule_conf, Rule, {'choice': False})
+                          c.validate_rule_conf, Rule, {'choice': False})
         self.assertRaises(config.YamlLintConfigError,
-                          config.validate_rule_conf, Rule, {'choice': 99})
+                          c.validate_rule_conf, Rule, {'choice': 99})
         self.assertRaises(config.YamlLintConfigError,
-                          config.validate_rule_conf, Rule, {'choice': 'abc'})
+                          c.validate_rule_conf, Rule, {'choice': 'abc'})
 
         Rule.CONF = {'choice': (int, 'hardcoded')}
         Rule.DEFAULT = {'choice': 1337}
-        config.validate_rule_conf(Rule, {'choice': 42})
-        config.validate_rule_conf(Rule, {'choice': 'hardcoded'})
-        config.validate_rule_conf(Rule, {})
+        c.validate_rule_conf(Rule, {'choice': 42})
+        c.validate_rule_conf(Rule, {'choice': 'hardcoded'})
+        c.validate_rule_conf(Rule, {})
         self.assertRaises(config.YamlLintConfigError,
-                          config.validate_rule_conf, Rule, {'choice': False})
+                          c.validate_rule_conf, Rule, {'choice': False})
         self.assertRaises(config.YamlLintConfigError,
-                          config.validate_rule_conf, Rule, {'choice': 'abc'})
+                          c.validate_rule_conf, Rule, {'choice': 'abc'})
 
         Rule.CONF = {'multiple': ['item1', 'item2', 'item3']}
         Rule.DEFAULT = {'multiple': ['item1']}
-        config.validate_rule_conf(Rule, {'multiple': []})
-        config.validate_rule_conf(Rule, {'multiple': ['item2']})
-        config.validate_rule_conf(Rule, {'multiple': ['item2', 'item3']})
-        config.validate_rule_conf(Rule, {})
+        c.validate_rule_conf(Rule, {'multiple': []})
+        c.validate_rule_conf(Rule, {'multiple': ['item2']})
+        c.validate_rule_conf(Rule, {'multiple': ['item2', 'item3']})
+        c.validate_rule_conf(Rule, {})
         self.assertRaises(config.YamlLintConfigError,
-                          config.validate_rule_conf, Rule,
+                          c.validate_rule_conf, Rule,
                           {'multiple': 'item1'})
         self.assertRaises(config.YamlLintConfigError,
-                          config.validate_rule_conf, Rule,
+                          c.validate_rule_conf, Rule,
                           {'multiple': ['']})
         self.assertRaises(config.YamlLintConfigError,
-                          config.validate_rule_conf, Rule,
+                          c.validate_rule_conf, Rule,
                           {'multiple': ['item1', 4]})
         self.assertRaises(config.YamlLintConfigError,
-                          config.validate_rule_conf, Rule,
+                          c.validate_rule_conf, Rule,
                           {'multiple': ['item4']})
 
     def test_invalid_rule(self):
@@ -719,6 +725,44 @@ class IgnoreConfigTestCase(unittest.TestCase):
             './s/s/ign-trail/s/s/file2.lint-me-anyway.yaml:3:3: ' + keydup,
             './s/s/ign-trail/s/s/file2.lint-me-anyway.yaml:4:17: ' + trailing,
             './s/s/ign-trail/s/s/file2.lint-me-anyway.yaml:5:5: ' + hyphen,
+        )))
+
+    def test_run_in_subdir_with_ignore_from_file(self):
+        with open(os.path.join(self.wd, '.yamllint'), 'w') as f:
+            f.write('extends: default\n'
+                    'ignore-from-file: .gitignore\n'
+                    'rules:\n'
+                    '  key-duplicates:\n'
+                    '    ignore-from-file: .ignore-key-duplicates\n')
+
+        with open(os.path.join(self.wd, '.gitignore'), 'w') as f:
+            f.write('*.dont-lint-me.yaml\n'
+                    '/bin/\n'
+                    '!/bin/*.lint-me-anyway.yaml\n')
+
+        with open(os.path.join(self.wd, '.ignore-key-duplicates'), 'w') as f:
+            f.write('/ign-dup\n')
+
+        sys.stdout = StringIO()
+        try:
+            os.chdir(os.path.join(self.wd, 'bin'))
+            with self.assertRaises(SystemExit):
+                cli.run(('-f', 'parsable', '.'))
+        finally:
+            os.chdir(self.wd)
+
+        out = sys.stdout.getvalue()
+        out = '\n'.join(sorted(out.splitlines()))
+
+        keydup = '[error] duplication of key "key" in mapping (key-duplicates)'
+        trailing = '[error] trailing spaces (trailing-spaces)'
+        hyphen = '[error] too many spaces after hyphen (hyphens)'
+
+        self.maxDiff = None
+        self.assertEqual(out, '\n'.join((
+            './file.lint-me-anyway.yaml:3:3: ' + keydup,
+            './file.lint-me-anyway.yaml:4:17: ' + trailing,
+            './file.lint-me-anyway.yaml:5:5: ' + hyphen,
         )))
 
     def test_run_with_ignored_from_file(self):

--- a/yamllint/config.py
+++ b/yamllint/config.py
@@ -31,6 +31,7 @@ class YamlLintConfig:
         assert (content is None) ^ (file is None)
 
         self.ignore = None
+        self.config_dir = None
 
         self.yaml_files = pathspec.PathSpec.from_lines(
             'gitwildmatch', ['*.yaml', '*.yml', '.yamllint'])
@@ -38,6 +39,7 @@ class YamlLintConfig:
         self.locale = None
 
         if file is not None:
+            self.config_dir = os.path.dirname(file)
             with open(file) as f:
                 content = f.read()
 
@@ -45,6 +47,8 @@ class YamlLintConfig:
         self.validate()
 
     def is_file_ignored(self, filepath):
+        if self.config_dir:
+            filepath = os.path.relpath(filepath, start=self.config_dir)
         return self.ignore and self.ignore.match_file(filepath)
 
     def is_yaml_file(self, filepath):
@@ -109,6 +113,11 @@ class YamlLintConfig:
                 raise YamlLintConfigError(
                     'invalid config: ignore-from-file should contain '
                     'filename(s), either as a list or string')
+            if self.config_dir is not None:
+                conf["ignore-from-file"] = [
+                    f if os.path.basename(f) != f
+                    else os.path.join(self.config_dir, f)
+                    for f in conf["ignore-from-file"]]
             with fileinput.input(conf['ignore-from-file']) as f:
                 self.ignore = pathspec.PathSpec.from_lines('gitwildmatch', f)
         elif 'ignore' in conf:
@@ -145,94 +154,101 @@ class YamlLintConfig:
             except Exception as e:
                 raise YamlLintConfigError(f'invalid config: {e}') from e
 
-            self.rules[id] = validate_rule_conf(rule, self.rules[id])
+            self.rules[id] = self.validate_rule_conf(rule, self.rules[id])
 
+    def validate_rule_conf(self, rule, conf):
+        if conf is False:  # disable
+            return False
 
-def validate_rule_conf(rule, conf):
-    if conf is False:  # disable
-        return False
+        if isinstance(conf, dict):
+            if ('ignore-from-file' in conf and not isinstance(
+                    conf['ignore-from-file'], pathspec.pathspec.PathSpec)):
+                if isinstance(conf['ignore-from-file'], str):
+                    conf['ignore-from-file'] = [conf['ignore-from-file']]
+                if not (isinstance(conf['ignore-from-file'], list)
+                        and all(isinstance(line, str)
+                                for line in conf['ignore-from-file'])):
+                    raise YamlLintConfigError(
+                        'invalid config: ignore-from-file should contain '
+                        'valid filename(s), either as a list or string')
+                if self.config_dir is not None:
+                    conf["ignore-from-file"] = [
+                        f if os.path.basename(f) != f
+                        else os.path.join(self.config_dir, f)
+                        for f in conf["ignore-from-file"]]
+                with fileinput.input(conf['ignore-from-file']) as f:
+                    conf['ignore'] = pathspec.PathSpec.from_lines(
+                        'gitwildmatch', f)
+            elif ('ignore' in conf and not isinstance(
+                    conf['ignore'], pathspec.pathspec.PathSpec)):
+                if isinstance(conf['ignore'], str):
+                    conf['ignore'] = pathspec.PathSpec.from_lines(
+                        'gitwildmatch', conf['ignore'].splitlines())
+                elif (isinstance(conf['ignore'], list) and
+                        all(isinstance(line, str) for line in conf['ignore'])):
+                    conf['ignore'] = pathspec.PathSpec.from_lines(
+                        'gitwildmatch', conf['ignore'])
+                else:
+                    raise YamlLintConfigError(
+                        'invalid config: ignore should contain file patterns')
 
-    if isinstance(conf, dict):
-        if ('ignore-from-file' in conf and not isinstance(
-                conf['ignore-from-file'], pathspec.pathspec.PathSpec)):
-            if isinstance(conf['ignore-from-file'], str):
-                conf['ignore-from-file'] = [conf['ignore-from-file']]
-            if not (isinstance(conf['ignore-from-file'], list)
-                    and all(isinstance(line, str)
-                            for line in conf['ignore-from-file'])):
+            if 'level' not in conf:
+                conf['level'] = 'error'
+            elif conf['level'] not in ('error', 'warning'):
                 raise YamlLintConfigError(
-                    'invalid config: ignore-from-file should contain '
-                    'valid filename(s), either as a list or string')
-            with fileinput.input(conf['ignore-from-file']) as f:
-                conf['ignore'] = pathspec.PathSpec.from_lines(
-                    'gitwildmatch', f)
-        elif ('ignore' in conf and not isinstance(
-                conf['ignore'], pathspec.pathspec.PathSpec)):
-            if isinstance(conf['ignore'], str):
-                conf['ignore'] = pathspec.PathSpec.from_lines(
-                    'gitwildmatch', conf['ignore'].splitlines())
-            elif (isinstance(conf['ignore'], list) and
-                    all(isinstance(line, str) for line in conf['ignore'])):
-                conf['ignore'] = pathspec.PathSpec.from_lines(
-                    'gitwildmatch', conf['ignore'])
-            else:
-                raise YamlLintConfigError(
-                    'invalid config: ignore should contain file patterns')
+                    'invalid config: level should be "error" or "warning"')
 
-        if 'level' not in conf:
-            conf['level'] = 'error'
-        elif conf['level'] not in ('error', 'warning'):
+            options = getattr(rule, 'CONF', {})
+            options_default = getattr(rule, 'DEFAULT', {})
+            for optkey in conf:
+                if optkey in ('ignore', 'ignore-from-file', 'level'):
+                    continue
+                if optkey not in options:
+                    raise YamlLintConfigError(
+                        f'invalid config: unknown option "{optkey}" for rule '
+                        f'"{rule.ID}"')
+                # Example: CONF = {option: (bool, 'mixed')}
+                #          → {option: true}         → {option: mixed}
+                if isinstance(options[optkey], tuple):
+                    if (conf[optkey] not in options[optkey] and
+                            type(conf[optkey]) not in options[optkey]):
+                        raise YamlLintConfigError(
+                            f'invalid config: option "{optkey}" of "{rule.ID}"'
+                            f' should be in {options[optkey]}')
+                # Example: CONF = {option: ['flag1', 'flag2', int]}
+                #          → {option: [flag1]}   → {option: [42, flag1, flag2]}
+                elif isinstance(options[optkey], list):
+                    if (not isinstance(conf[optkey], list) or
+                            any(flag not in options[optkey] and
+                                type(flag) not in options[optkey]
+                                for flag in conf[optkey])):
+                        raise YamlLintConfigError(
+                            f'invalid config: option "{optkey}" of "{rule.ID}"'
+                            f' should only contain values in {options[optkey]}'
+                        )
+                # Example: CONF = {option: int}
+                #          → {option: 42}
+                else:
+                    if not isinstance(conf[optkey], options[optkey]):
+                        raise YamlLintConfigError(
+                            f'invalid config: option "{optkey}" of "{rule.ID}"'
+                            f' should be {options[optkey].__name__}')
+            for optkey in options:
+                if optkey not in conf:
+                    conf[optkey] = options_default[optkey]
+
+            if hasattr(rule, 'VALIDATE'):
+                res = rule.VALIDATE(conf)
+                if res:
+                    raise YamlLintConfigError(
+                        f'invalid config: {rule.ID}: {res}'
+                    )
+        else:
             raise YamlLintConfigError(
-                'invalid config: level should be "error" or "warning"')
+                f'invalid config: rule "{rule.ID}": should be either "enable",'
+                f' "disable" or a dict')
 
-        options = getattr(rule, 'CONF', {})
-        options_default = getattr(rule, 'DEFAULT', {})
-        for optkey in conf:
-            if optkey in ('ignore', 'ignore-from-file', 'level'):
-                continue
-            if optkey not in options:
-                raise YamlLintConfigError(
-                    f'invalid config: unknown option "{optkey}" for rule '
-                    f'"{rule.ID}"')
-            # Example: CONF = {option: (bool, 'mixed')}
-            #          → {option: true}         → {option: mixed}
-            if isinstance(options[optkey], tuple):
-                if (conf[optkey] not in options[optkey] and
-                        type(conf[optkey]) not in options[optkey]):
-                    raise YamlLintConfigError(
-                        f'invalid config: option "{optkey}" of "{rule.ID}" '
-                        f'should be in {options[optkey]}')
-            # Example: CONF = {option: ['flag1', 'flag2', int]}
-            #          → {option: [flag1]}      → {option: [42, flag1, flag2]}
-            elif isinstance(options[optkey], list):
-                if (not isinstance(conf[optkey], list) or
-                        any(flag not in options[optkey] and
-                            type(flag) not in options[optkey]
-                            for flag in conf[optkey])):
-                    raise YamlLintConfigError(
-                        f'invalid config: option "{optkey}" of "{rule.ID}" '
-                        f'should only contain values in {options[optkey]}')
-            # Example: CONF = {option: int}
-            #          → {option: 42}
-            else:
-                if not isinstance(conf[optkey], options[optkey]):
-                    raise YamlLintConfigError(
-                        f'invalid config: option "{optkey}" of "{rule.ID}" '
-                        f'should be {options[optkey].__name__}')
-        for optkey in options:
-            if optkey not in conf:
-                conf[optkey] = options_default[optkey]
-
-        if hasattr(rule, 'VALIDATE'):
-            res = rule.VALIDATE(conf)
-            if res:
-                raise YamlLintConfigError(f'invalid config: {rule.ID}: {res}')
-    else:
-        raise YamlLintConfigError(
-            f'invalid config: rule "{rule.ID}": should be either "enable", '
-            f'"disable" or a dict')
-
-    return conf
+        return conf
 
 
 def get_extended_config_file(name):


### PR DESCRIPTION
This fixes the problem (#673) that files mentioned in ignore-from-file can not be found when running in a subdirectory. Values in ignore-from-file are now treated as being relative to the config file.