### PR TITLE
fix: allow backslash-escaped special characters in double-quoted strings (#700)

### DIFF
--- a/tests/rules/test_quoted_strings.py
+++ b/tests/rules/test_quoted_strings.py
@@ -14,6 +14,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 from tests.common import RuleTestCase
+import yaml.reader
 
 from yamllint import config
 
@@ -474,6 +475,30 @@ class QuotedValuesTestCase(RuleTestCase):
                    '- foo bar\n'
                    '- "foo bar"\n',
                    conf, problem1=(3, 3), problem2=(7, 3), problem3=(11, 3))
+
+    def test_only_when_needed_special_characters(self):
+        conf = 'quoted-strings: {required: only-when-needed}\n'
+        self.check('---\n'
+                   'k1: "\\u001b"\n',
+                   conf)
+        self.check('---\n'
+                   "k1: '\\u001b'\n",
+                   conf, problem=(2, 5))
+        self.check('---\n'
+                   'k1: \\u001b\n',
+                   conf)
+        self.assertRaises(yaml.reader.ReaderError, self.check,
+                          '---\n'
+                          'k1: "\u001b"\n',
+                          conf)
+        self.assertRaises(yaml.reader.ReaderError, self.check,
+                          '---\n'
+                          "k1: '\u001b'\n",
+                          conf)
+        self.assertRaises(yaml.reader.ReaderError, self.check,
+                          '---\n'
+                          'k1: \u001b\n',
+                          conf)
 
     def test_octal_values(self):
         conf = 'quoted-strings: {required: true}\n'


### PR DESCRIPTION
- Add test case to reproduce #700 
- When checking whether quotes are needed, assume that double-quoted strings containing special characters have already been escaped (and claim the quotes are in fact needed)
