### PR TITLE
CI: Add support for Python 3.13

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -39,11 +39,11 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-          - '3.8'
           - '3.9'
           - '3.10'
           - '3.11'
           - '3.12'
+          - '3.13'
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
And drop support for Python 3.8 (end-of-life since 2024-10-07).