### PR TITLE
cli: Fix TTY test failing on Python 3.14

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -13,7 +13,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import fcntl
 import locale
 import os
 import pty
@@ -510,8 +509,7 @@ class CommandLineTestCase(unittest.TestCase):
 
         # Read output from TTY
         output = os.fdopen(master, 'r')
-        flag = fcntl.fcntl(master, fcntl.F_GETFD)
-        fcntl.fcntl(master, fcntl.F_SETFL, flag | os.O_NONBLOCK)
+        os.set_blocking(master, False)
 
         out = output.read().replace('\r\n', '\n')
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -499,7 +499,7 @@ class CommandLineTestCase(unittest.TestCase):
 
         # Create a pseudo-TTY and redirect stdout to it
         master, slave = pty.openpty()
-        sys.stdout = sys.stderr = os.fdopen(slave, 'w')
+        sys.stdout = os.fdopen(slave, 'w')
 
         with self.assertRaises(SystemExit) as ctx:
             cli.run((path, ))
@@ -514,7 +514,6 @@ class CommandLineTestCase(unittest.TestCase):
         out = output.read().replace('\r\n', '\n')
 
         sys.stdout.close()
-        sys.stderr.close()
         output.close()
 
         self.assertEqual(out, (


### PR DESCRIPTION
### cli: Refactor old test to avoid fcntl

This is a simple preparation for the next commit, to get rid of
low-level `fcntl.fcntl()` calls, since `os.set_blocking()` now exists
(since Python 3.5).

---

### cli: Fix TTY test failing on Python 3.14

Since I don't have Python 3.14 on my system (yet), here are the steps I
used to reproduce:

    sudo dnf install python3.14
    python3.14 -m venv /tmp/py3.14
    source /tmp/py3.14/bin/activate
    pip install yaml pathspec
    python3.14 -m unittest discover
    # or
    python3.14 -m unittest tests.test_cli.CommandLineTestCase.test_run_default_format_output_in_tty

This commit fixes that by piping *only* `sys.stdout`, not `sys.stderr`
too. I'm not sure why I wrote this code in 2016 (see commit a2c68fdf),
but the new one makes more sense to me now.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=2336947