### PR TITLE
Fix UnicodeDecodeError when running `yamllint` under certain Windows code pages

### DIFF
--- a/yamllint/linter.py
+++ b/yamllint/linter.py
@@ -229,7 +229,13 @@ def run(input, conf, filepath=None):
         return _run(input, conf, filepath)
     elif isinstance(input, io.IOBase):
         # We need to have everything in memory to parse correctly
-        content = input.read()
+        if hasattr(input, 'encoding') and input.encoding:
+            if input.encoding.lower() != 'utf-8' and hasattr(input, 'buffer'):
+                content = input.buffer.read().decode('utf-8')
+            else:
+                content = input.read()
+        else:
+            content = input.read().decode('utf-8')
         return _run(content, conf, filepath)
     else:
         raise TypeError('input should be a string or a stream')


### PR DESCRIPTION
This PR addresses an issue where running `yamllint` (via pre-commit) on Windows with a non-UTF-8 code page (like CP1254) could trigger a UnicodeDecodeError. The problem occurred because yamllint was attempting to read and decode the file contents using the default system encoding, which didn’t properly handle certain characters.

```
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "C:\<pyenv>\Scripts\yamllint.EXE\__main__.py", line 7, in <module>   
  File "C:\<pyenv>\Lib\site-packages\yamllint\cli.py", line 223, in run     
    problems = linter.run(f, conf, filepath)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\<pyenv>\Lib\site-packages\yamllint\linter.py", line 232, in run  
    content = input.read()
              ^^^^^^^^^^^^
  File "C:\<python>\Lib\encodings\cp1254.py", line 23, in decode
    return codecs.charmap_decode(input,self.errors,decoding_table)[0]
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
UnicodeDecodeError: 'charmap' codec can't decode byte 0x8f in position 296: character maps to <undefined>
```

To fix this, I updated the file-reading logic to:
- Check if input.encoding is set and if it’s neither UTF-8 nor buffer.
- If so, read from input.buffer directly.
- Otherwise, read and decode with UTF-8.

And it worked well:
![image](https://github.com/user-attachments/assets/2916a5e8-02ba-4551-85ea-af0d1f70c880)

Thanks for reviewing.