### PR TITLE
key-ordering: Add ignored-keys option

### DIFF
--- a/tests/rules/test_key_ordering.py
+++ b/tests/rules/test_key_ordering.py
@@ -147,3 +147,25 @@ class KeyOrderingTestCase(RuleTestCase):
                    'hais: true\n'
                    'haïr: true\n', conf,
                    problem=(3, 1))
+
+    def test_ignored_keys(self):
+        conf = ('key-ordering:\n'
+                '  ignored-keys: ["n(a|o)me", "^b"]\n')
+        self.check('---\n'
+                   'a:\n'
+                   'b:\n'
+                   'c:\n'
+                   'name: ignored\n'
+                   'first-name: ignored\n'
+                   'nome: ignored\n'
+                   'gnomes: ignored\n'
+                   'd:\n'
+                   'e:\n'
+                   'boat: ignored\n'
+                   '.boat: ERROR\n'
+                   'call: ERROR\n'
+                   'f:\n'
+                   'g:\n',
+                   conf,
+                   problem1=(12, 1),
+                   problem2=(13, 1))


### PR DESCRIPTION
This change allows ignoring certain keys by filling the `ignored-keys` option with a list of PCRE regexes to select strings to ignore.

---

Note: this is a follow up of the pull request at https://github.com/adrienverge/yamllint/pull/689, see why [on this comment](https://github.com/adrienverge/yamllint/pull/689#issuecomment-2701603867).