### PR TITLE
Drop support for Python 3.8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "yamllint"
 description = "A linter for YAML files."
 readme = {file = "README.rst", content-type = "text/x-rst"}
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 license = {text = "GPL-3.0-or-later"}
 authors = [{name = "Adrien Vergé"}]
 keywords = ["yaml", "lint", "linter", "syntax", "checker"]


### PR DESCRIPTION
This fixes a leftover from commit c20f191 "CI: Add support for Python 3.13".

Python 3.8 is officially "end-of-life" since 2024-10-07.

Fixes https://github.com/adrienverge/yamllint/issues/717