### PR TITLE
restore full test suite to sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+recursive-include tests *.*


### PR DESCRIPTION
Congratulations on 1.36.1, and as always thank you for maintaining this tool!

[Downstream](https://github.com/conda-forge/yamllint-feedstock/pull/45) we noted that the `tests` folder is incomplete, failing to import with `tests.common` being missing. We shipped just getting those files from the GitHub-generated tarball, but it is generally to convenient to have a single canonical, immutable file (and SHA) to track.

I don't _think_ `sdist`-only files can be added directly in `pyproject.toml` with the `setuptools` legacy backend, so this PR adds a one-liner `MANIFEST.in` to preserve all the files in `tests` in the sdist. 

Thanks again!