### PR TITLE
build: Restore documentation and test files in sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,3 @@
+include *.rst
+include docs/Makefile docs/*.py docs/*.rst docs/*.png
+include tests/*.py tests/rules/*.py tests/yaml-1.2-spec-examples/example-*


### PR DESCRIPTION
This commit fixes a problem reported by Nicholas Bollweg at https://github.com/adrienverge/yamllint/pull/725. Recent commit a3e1325 "CI: Publish PyPI releases using GitHub Actions workflows" and automatic publication of version 1.36.1 revealed a problem that had probably been there for some time: most documentation and test files weren't included in the source distribution when running `python -m build` (unless an `yamllint.egg-info` from a previous run listed them).

I see two solutions:
1. Add plugin `setuptools-scm` in `pyproject.toml`:
   ```toml
   requires = ["setuptools >= 61", "setuptools-scm >= 8"]
   ```
   This would add all files tracked by Git in the sdist, including a few that aren't really needed: `.flake8`, `.github`, `.readthedocs.yaml`…
2. Declare extra files to embed in `MANIFEST.in`. This is what this commit does.

I checked that:
- All files packages before 1.36.0 are correctly included now:
  ```bash
  tar -tvf dist/yamllint-1.36.0.tar.gz | cut -b65- \
    > /tmp/sdist-files-before
  rm -rf yamllint.egg-info && python -m build && \
    tar -tvf dist/yamllint-1.36.1.tar.gz | cut -b65- \
    > /tmp/sdist-files-after
  git diff --no-index /tmp/sdist-files-before /tmp/sdist-files-after
  ```
- These extra files are still not installed by `pip install` (they are not needed):
  ```bash
  pip install yamllint==1.36.0 && \
    tree ~/.local/lib/python3.13/site-packages/yamllint \
    > /tmp/pip-install-before
  pip install dist/yamllint-1.36.1.tar.gz && \
    tree ~/.local/lib/python3.13/site-packages/yamllint \
    > /tmp/pip-install-after
  git diff --no-index /tmp/pip-install-before /tmp/pip-install-after
  ```