### PR TITLE
CI: Ignore version duplicates when publishing to TestPyPI

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -46,6 +46,7 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           repository-url: https://test.pypi.org/legacy/
+          skip-existing: true
 
   publish-to-pypi:
     name: Publish distribution package to PyPI


### PR DESCRIPTION
This commit prevents the failure of the GitHub Actions job "Publish distribution package to TestPyPI" on most pushes (see discussion at https://github.com/adrienverge/yamllint/issues/721#issuecomment-2727167030), since recent commit a3e1325 "CI: Publish PyPI releases using GitHub Actions workflows".

Indeed, TestPyPI doesn't allow repushing the same version. Use `skip-existing` to prevent to such failures on the CI.

An alternative would be to use the `setuptools-scm` plugin to define a unique version for each commit (e.g. `1.36.2.dev2+gd4f1c14`), but it requires more changes (define the version in `pyproject.toml`, fetch tags from GitHub in `publish.yaml`, exclude `.*` + `.github/**` files in `MANIFEST.in`). Moreover it doesn't work as is: to prevent errors like `HTTP 400 The use of local versions in '1.36.2.dev2+gd4f1c14' is not allowed` we would need `local_scheme = "no-local-version"`, which would push duplicated versions on TestPyPI anyway.