### PR TITLE
CI: Fix TestPyPI "dev0" versions for master commits on tags

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -24,8 +24,9 @@ jobs:
       - name: Add '.devN' to version for non-tag builds
         if: github.ref_type != 'tag'
         run:
+          N=$(git describe --tags --long | cut -d- -f2);
           sed -i
-          "/^APP_VERSION = /s/'$/.dev$(git describe --tags | cut -d- -f2)'/"
+          "/^APP_VERSION = /s/'$/.dev$N'/"
           yamllint/__init__.py
       - name: Build a binary wheel and a source tarball
         run: python -m build


### PR DESCRIPTION
This fixes a problem in the custom versions `v1.37.0.devN` built for publishing on TestPyPI since commit 325fafa "Publish each master commit with a unique version on TestPyPI".

Such versions are constructed by suffixing `.devN`, where `N` is the number of commits since last tags. In the `N = 0` case, we need to add `--long` to `git describe --tags`. Otherwise it yields `v1.37.0` instead of `v1.37.0-0-gbe92e15`, and the CI fails, e.g. on https://github.com/adrienverge/yamllint/actions/runs/14017589005/job/39245225221

    packaging.version.InvalidVersion: Invalid version: '1.37.0.devv1.37.0'