### PR TITLE
Fix the badge link in `README.md`

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -8,8 +8,8 @@ repetition and cosmetic problems such as lines length, trailing spaces,
 indentation, etc.
 
 .. image::
-   https://github.com/adrienverge/yamllint/actions/workflows/ci.yaml/badge.svg?branch=master
-   :target: https://github.com/adrienverge/yamllint/actions/workflows/ci.yaml?query=branch%3Amaster
+   https://github.com/adrienverge/yamllint/actions/workflows/tests.yaml/badge.svg?branch=master
+   :target: https://github.com/adrienverge/yamllint/actions/workflows/tests.yaml?query=branch%3Amaster
    :alt: CI tests status
 .. image::
    https://coveralls.io/repos/github/adrienverge/yamllint/badge.svg?branch=master


### PR DESCRIPTION
Updated the link to the test ci status, according to the changes made in commit 1c3bbb2.