### PR TITLE
Add error check for invalid config

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -199,6 +199,10 @@ class SimpleConfigTestCase(unittest.TestCase):
     def test_invalid_rule(self):
         with self.assertRaisesRegex(
                 config.YamlLintConfigError,
+                'invalid config: rules should be a dict'):
+            config.YamlLintConfig('rules:\n')
+        with self.assertRaisesRegex(
+                config.YamlLintConfigError,
                 'invalid config: rule "colons": should be either '
                 '"enable", "disable" or a dict'):
             config.YamlLintConfig('rules:\n'

--- a/yamllint/config.py
+++ b/yamllint/config.py
@@ -82,6 +82,8 @@ class YamlLintConfig:
             raise YamlLintConfigError('invalid config: not a dict')
 
         self.rules = conf.get('rules', {})
+        if not isinstance(self.rules, dict):
+            raise YamlLintConfigError('invalid config: rules should be a dict')
         for rule in self.rules:
             if self.rules[rule] == 'enable':
                 self.rules[rule] = {}


### PR DESCRIPTION
In the current version, the error message states `TypeError: 'NoneType' object is not iterable` when the 'rules' in the config file is not a dict (gh-274.) It would be helpful to improve the error message.

Additionally, it is for consistency, as other elements(`ignore`, `locale`, etc.) have similar error checks.