### PR TITLE
Fix link markup in the documentation

### DIFF
--- a/docs/integration.rst
+++ b/docs/integration.rst
@@ -52,7 +52,7 @@ Integration with GitLab
 
 You can use the following GitLab CI/CD stage to run yamllint and get the
 results as a `Code quality (Code Climate)
-<https://docs.gitlab.com/ee/ci/testing/code_quality.html>` report.
+<https://docs.gitlab.com/ee/ci/testing/code_quality.html>`_ report.
 
 .. code:: yaml
 


### PR DESCRIPTION
Appended a missing underscore so the link works correctly.