### PR TITLE
config: Use "mapping" instead of "dict" for user-facing errors

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -270,7 +270,7 @@ class CommandLineTestCase(unittest.TestCase):
             cli.run(('-d', '', 'file'))
         self.assertEqual(ctx.returncode, -1)
         self.assertEqual(ctx.stdout, '')
-        self.assertRegex(ctx.stderr, r'^invalid config: not a dict')
+        self.assertRegex(ctx.stderr, r'^invalid config: not a mapping')
 
     def test_run_with_implicit_extends_config(self):
         path = os.path.join(self.wd, 'warn.yaml')

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -199,12 +199,12 @@ class SimpleConfigTestCase(unittest.TestCase):
     def test_invalid_rule(self):
         with self.assertRaisesRegex(
                 config.YamlLintConfigError,
-                'invalid config: rules should be a dict'):
+                'invalid config: rules should be a mapping'):
             config.YamlLintConfig('rules:\n')
         with self.assertRaisesRegex(
                 config.YamlLintConfigError,
                 'invalid config: rule "colons": should be either '
-                '"enable", "disable" or a dict'):
+                '"enable", "disable" or a mapping'):
             config.YamlLintConfig('rules:\n'
                                   '  colons: invalid\n')
 

--- a/yamllint/config.py
+++ b/yamllint/config.py
@@ -79,11 +79,12 @@ class YamlLintConfig:
             raise YamlLintConfigError(f'invalid config: {e}') from e
 
         if not isinstance(conf, dict):
-            raise YamlLintConfigError('invalid config: not a dict')
+            raise YamlLintConfigError('invalid config: not a mapping')
 
         self.rules = conf.get('rules', {})
         if not isinstance(self.rules, dict):
-            raise YamlLintConfigError('invalid config: rules should be a dict')
+            raise YamlLintConfigError('invalid config: rules should be a '
+                                      'mapping')
         for rule in self.rules:
             if self.rules[rule] == 'enable':
                 self.rules[rule] = {}
@@ -235,7 +236,7 @@ def validate_rule_conf(rule, conf):
     else:
         raise YamlLintConfigError(
             f'invalid config: rule "{rule.ID}": should be either "enable", '
-            f'"disable" or a dict')
+            f'"disable" or a mapping')
 
     return conf
 


### PR DESCRIPTION
Previously, these errors used the word "dict" because it's the common term in the Python world. But the YAML term is rather "mapping". The present commit fixes this wording.

This originates from this discussion [^2].

[^1]: https://yaml.org/spec/1.2.2/#3211-nodes
[^2]: https://github.com/adrienverge/yamllint/pull/747#pullrequestreview-2813393998