### PR TITLE
Fix deprecated license specification format

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,14 +3,13 @@ name = "yamllint"
 description = "A linter for YAML files."
 readme = {file = "README.rst", content-type = "text/x-rst"}
 requires-python = ">=3.9"
-license = {text = "GPL-3.0-or-later"}
+license = "GPL-3.0-or-later"
 authors = [{name = "Adrien Vergé"}]
 keywords = ["yaml", "lint", "linter", "syntax", "checker"]
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Environment :: Console",
     "Intended Audience :: Developers",
-    "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
     "Programming Language :: Python",
     "Topic :: Software Development",
     "Topic :: Software Development :: Debuggers",


### PR DESCRIPTION
In the current version, `pip install .` emits the following warnings:
```
********************************************************************************
Please use a simple string containing a SPDX expression for `project.license`. You can also use `project.license-files`. (Both options available on setuptools>=77.0.0).

By 2026-Feb-18, you need to update your project and remove deprecated calls
or your builds will no longer be supported.

See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license for details.
********************************************************************************
```
```
********************************************************************************
Please consider removing the following classifiers in favor of a SPDX license expression:

License :: OSI Approved :: GNU General Public License v3 (GPLv3)

See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license for details.
********************************************************************************
```
(These warnings can be seen by using `--log` option.)

So fixed the way to specify the license as these warnings suggest. Also see https://peps.python.org/pep-0639/#deprecate-license-classifiers and https://peps.python.org/pep-0639/#deprecate-license-key-table-subkeys.