### PR TITLE
improve get_extended_config_file with expansions

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -40,13 +40,6 @@ class ConfigFilenameExpansion(unittest.TestCase):
         result = get_extended_config_file(input_path)
         self.assertEqual(result, expected)
 
-    def test_env_var_expansion(self):
-        os.environ["TEST_PATH"] = "/tmp/test.yml"
-        input_path = "$TEST_PATH"
-        expected = "/tmp/test.yml"
-        result = get_extended_config_file(input_path)
-        self.assertEqual(result, expected)
-
     def test_no_expansion(self):
         result = get_extended_config_file('asis.yml')
         self.assertEqual(result, 'asis.yml')

--- a/yamllint/config.py
+++ b/yamllint/config.py
@@ -246,10 +246,6 @@ def get_extended_config_file(name):
     if name.startswith('~'):
         name = os.path.expanduser(name)
 
-    # Expand variables if present
-    if '$' in name:
-        name = os.path.expandvars(name)
-
     # Is it a standard conf shipped with yamllint...
     if '/' not in name:
         std_conf = os.path.join(os.path.dirname(os.path.realpath(__file__)),


### PR DESCRIPTION
This PR improves get_extended_config_file function providing it with
the ability to expand variables and tilde so you can use more complex
values in `extends:`.

Example 1:

```
extends: ~/repos/github.com/freehck/linting-rules/.yamllint
```

Example 2:

```
extends: $HOME/repos/github.com/freehck/linting-rules/.yamllint
```

Example 3:

```
extends: ${HOME}/repos/github.com/freehck/linting-rules/.yamllint
```

This is useful to store company's linting rules in a separate
repository.