### PR TITLE
build: PEP 639 support requires setuptools ≥ 77

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ documentation = "https://yamllint.readthedocs.io"
 
 [build-system]
 build-backend = "setuptools.build_meta"
-requires = ["setuptools >= 61"]
+requires = ["setuptools >= 77.0.3"]
 
 [tool.setuptools]
 packages = ["yamllint", "yamllint.conf", "yamllint.rules"]


### PR DESCRIPTION
https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license-and-license-files