### PR TITLE
quoted-strings: Add missing quote-type: consistent docs

### DIFF
--- a/yamllint/rules/quoted_strings.py
+++ b/yamllint/rules/quoted_strings.py
@@ -20,8 +20,8 @@ used.
 
 .. rubric:: Options
 
-* ``quote-type`` defines allowed quotes: ``single``, ``double`` or ``any``
-  (default).
+* ``quote-type`` defines allowed quotes: ``single``, ``double``, ``consistent``
+  or ``any`` (default).
 * ``required`` defines whether using quotes in string values is required
   (``true``, default) or not (``false``), or only allowed when really needed
   (``only-when-needed``).


### PR DESCRIPTION
Commit e3d54cc was missing a reference to the new `consistent` functionality in `quote-type`.

Thanks to @kleinschrader in adrienverge/yamllint#776 for noticing this.