### PR TITLE
Include Alpine Linux installation for yamllint

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -35,6 +35,12 @@ On OpenBSD:
 
   doas pkg_add py-yamllint
 
+On Alpine Linux:
+
+.. code:: bash
+
+  pkg add yamllint
+
 Alternatively using pip, the Python package manager:
 
 .. code:: bash


### PR DESCRIPTION
https://pkgs.alpinelinux.org/package/edge/community/x86/yamllint

Looks like this exists and is regularly updated. Adding this in the quickstart guide can help people find it, especially in Docker contexts.