### PR TITLE
Drop support for Python 3.9

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -42,7 +42,6 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-          - '3.9'
           - '3.10'
           - '3.11'
           - '3.12'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "yamllint"
 description = "A linter for YAML files."
 readme = {file = "README.rst", content-type = "text/x-rst"}
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 license = "GPL-3.0-or-later"
 authors = [{name = "Adrien Vergé"}]
 keywords = ["yaml", "lint", "linter", "syntax", "checker"]

--- a/tests/common.py
+++ b/tests/common.py
@@ -23,7 +23,6 @@ import shutil
 import sys
 import tempfile
 import unittest
-import warnings
 
 import yaml
 
@@ -90,13 +89,7 @@ def register_test_codecs():
 
 
 def unregister_test_codecs():
-    if sys.version_info >= (3, 10, 0):
-        codecs.unregister(test_codec_infos.get)
-    else:
-        warnings.warn(
-            "This version of Python doesn’t allow us to unregister codecs.",
-            stacklevel=1
-        )
+    codecs.unregister(test_codec_infos.get)
 
 
 def is_test_codec(codec):


### PR DESCRIPTION
Python 3.9 is officially "end-of-life" since 2025-10-31.

Note: Python 3.14 is officially supported since commit 823a96e "CI: Test more versions of Python".