### PR TITLE
[pathspec >= 1.0.0] Update with `GitIgnoreSpec.from_lines`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ classifiers = [
     "Topic :: Software Development :: Testing",
 ]
 dependencies = [
-    "pathspec >= 0.5.3",
+    "pathspec >= 1.0.3",
     "pyyaml",
 ]
 dynamic = ["version"]

--- a/yamllint/config.py
+++ b/yamllint/config.py
@@ -32,8 +32,8 @@ class YamlLintConfig:
 
         self.ignore = None
 
-        self.yaml_files = pathspec.PathSpec.from_lines(
-            'gitwildmatch', ['*.yaml', '*.yml', '.yamllint'])
+        self.yaml_files = pathspec.GitIgnoreSpec.from_lines(
+            ['*.yaml', '*.yml', '.yamllint'])
 
         self.locale = None
 
@@ -112,18 +112,17 @@ class YamlLintConfig:
                 raise YamlLintConfigError(
                     'invalid config: ignore-from-file should contain '
                     'filename(s), either as a list or string')
-            self.ignore = pathspec.PathSpec.from_lines(
-                'gitwildmatch',
+            self.ignore = pathspec.GitIgnoreSpec.from_lines(
                 decoder.lines_in_files(conf['ignore-from-file'])
             )
         elif 'ignore' in conf:
             if isinstance(conf['ignore'], str):
-                self.ignore = pathspec.PathSpec.from_lines(
-                    'gitwildmatch', conf['ignore'].splitlines())
+                self.ignore = pathspec.GitIgnoreSpec.from_lines(
+                    conf['ignore'].splitlines())
             elif (isinstance(conf['ignore'], list) and
                     all(isinstance(line, str) for line in conf['ignore'])):
-                self.ignore = pathspec.PathSpec.from_lines(
-                    'gitwildmatch', conf['ignore'])
+                self.ignore = pathspec.GitIgnoreSpec.from_lines(
+                    conf['ignore'])
             else:
                 raise YamlLintConfigError(
                     'invalid config: ignore should contain file patterns')
@@ -134,8 +133,8 @@ class YamlLintConfig:
                 raise YamlLintConfigError(
                     'invalid config: yaml-files '
                     'should be a list of file patterns')
-            self.yaml_files = pathspec.PathSpec.from_lines('gitwildmatch',
-                                                           conf['yaml-files'])
+            self.yaml_files = pathspec.GitIgnoreSpec.from_lines(
+                conf['yaml-files'])
 
         if 'locale' in conf:
             if not isinstance(conf['locale'], str):
@@ -168,19 +167,18 @@ def validate_rule_conf(rule, conf):
                 raise YamlLintConfigError(
                     'invalid config: ignore-from-file should contain '
                     'valid filename(s), either as a list or string')
-            conf['ignore'] = pathspec.PathSpec.from_lines(
-                'gitwildmatch',
+            conf['ignore'] = pathspec.GitIgnoreSpec.from_lines(
                 decoder.lines_in_files(conf['ignore-from-file'])
             )
         elif ('ignore' in conf and not isinstance(
                 conf['ignore'], pathspec.pathspec.PathSpec)):
             if isinstance(conf['ignore'], str):
-                conf['ignore'] = pathspec.PathSpec.from_lines(
-                    'gitwildmatch', conf['ignore'].splitlines())
+                conf['ignore'] = pathspec.GitIgnoreSpec.from_lines(
+                    conf['ignore'].splitlines())
             elif (isinstance(conf['ignore'], list) and
                     all(isinstance(line, str) for line in conf['ignore'])):
-                conf['ignore'] = pathspec.PathSpec.from_lines(
-                    'gitwildmatch', conf['ignore'])
+                conf['ignore'] = pathspec.GitIgnoreSpec.from_lines(
+                    conf['ignore'])
             else:
                 raise YamlLintConfigError(
                     'invalid config: ignore should contain file patterns')


### PR DESCRIPTION
To follow Git's implementation, use GitIgnoreSpec.from_lines(...). The change for using this is Git allows including files from excluded directories which directly contradicts the gitignore docs.

See https://github.com/adrienverge/yamllint/issues/800#issuecomment-3716842204

Fixes https://github.com/adrienverge/yamllint/issues/800