### PR TITLE
fix: ignore list not being used when passing files/directories as arguments

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -151,7 +151,7 @@ It is possible to exclude specific files or directories, so that the linter
 doesn't process them. They can be provided either as a list of paths, or as a
 bulk string.
 
-You can either totally ignore files (they won't be looked at):
+You can exclude files found during directory traversal:
 
 .. code-block:: yaml
 
@@ -238,6 +238,43 @@ without really linting them, you can use ``--list-files``:
 .. code:: bash
 
  yamllint --list-files .
+
+Forcing exclusion of explicitly specified files
+-----------------------------------------------
+
+By default, yamllint lints files explicitly passed on the command line even if
+they match ``ignore`` or ``ignore-from-file`` patterns. This lets you check an
+individual file that would normally be excluded during directory traversal.
+
+Use ``--force-exclude`` to skip matching files before opening them:
+
+.. code:: bash
+
+ yamllint --force-exclude changed-file.yaml generated-file.yaml
+
+This is useful for tools that pass a list of changed files to yamllint, such as
+pre-commit hooks or continuous integration jobs. You can also enable it in your
+configuration:
+
+.. code-block:: yaml
+
+ extends: default
+ force-exclude: true
+ ignore: |
+   generated/
+   *.template.yaml
+
+``force-exclude`` is a boolean and defaults to ``false``. It is inherited from
+extended configurations and can be overridden in a derived configuration.
+The command-line flag enables it even if the configuration sets it to ``false``.
+Ignored files are skipped silently; if all files are skipped, yamllint exits
+successfully. This option applies to global ignore patterns, not rule-specific
+ignores.
+
+Files found by traversing directories always respect ignore patterns, including
+negated patterns that include files again. ``--list-files`` follows the same
+selection as linting: explicitly named files are included unless
+``force-exclude`` is enabled. Standard input is unaffected.
 
 Setting the locale
 ------------------

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -22,6 +22,7 @@ import shutil
 import sys
 import tempfile
 import unittest
+from unittest.mock import patch
 
 from tests.common import (
     RunContext,
@@ -734,8 +735,126 @@ class CommandLineTestCase(unittest.TestCase):
         self.assertEqual(ctx.returncode, 0)
         self.assertEqual(
             sorted(ctx.stdout.splitlines()),
-            [os.path.join(self.wd, 'a.yaml')]
+            [os.path.join(self.wd, name)
+             for name in ('a.yaml', 'c.yaml', 'en.yaml')]
         )
+
+
+class ForceExcludeTestCase(unittest.TestCase):
+    def test_explicit_ignored_files(self):
+        workspace = {
+            'ignored.yaml': 'key: value  \n',
+            'included.yaml': 'key: value  \n',
+            '.gitignore': 'ignored.yaml\nmissing.yaml\n',
+        }
+        for ignore in ('ignore: [ignored.yaml, missing.yaml]',
+                       'ignore-from-file: .gitignore'):
+            for setting, flags in (('', ()), ('force-exclude: false', ()),
+                                   ('force-exclude: true', ()),
+                                   ('', ('--force-exclude',)),
+                                   ('force-exclude: false',
+                                    ('--force-exclude',))):
+                with self.subTest(ignore=ignore, setting=setting, flags=flags):
+                    conf = (f'{ignore}\n{setting}\n'
+                            'rules: {trailing-spaces: enable}\n')
+                    force = setting == 'force-exclude: true' or bool(flags)
+                    with temp_workspace(workspace):
+                        # Force-excluded files must never be opened.
+                        with patch('yamllint.cli.open', wraps=open) as opened:
+                            with RunContext(self) as ctx:
+                                cli.run(('-d', conf, '-f', 'parsable', *flags,
+                                         'ignored.yaml', 'included.yaml'))
+                        paths = [call.args[0]
+                                 for call in opened.call_args_list]
+                        self.assertEqual('ignored.yaml' in paths, not force)
+                        self.assertIn('included.yaml', paths)
+                        self.assertEqual(ctx.returncode, 1)
+                        self.assertEqual(ctx.stderr, '')
+                        expected = ['included.yaml']
+                        if not force:
+                            expected.insert(0, 'ignored.yaml')
+                        self.assertEqual(
+                            ctx.stdout,
+                            ''.join(f'{name}:1:11: [error] trailing spaces '
+                                    '(trailing-spaces)\n'
+                                    for name in expected))
+                        with RunContext(self) as ctx:
+                            cli.run(('-d', conf, '--list-files', *flags,
+                                     'ignored.yaml', 'included.yaml'))
+                        self.assertEqual(ctx.returncode, 0)
+                        self.assertEqual(ctx.stderr, '')
+                        self.assertEqual(ctx.stdout.splitlines(), expected)
+
+                        with RunContext(self) as ctx:
+                            cli.run(('-d', conf, *flags, 'missing.yaml'))
+                        self.assertEqual(ctx.returncode, 0 if force else -1)
+                        self.assertEqual(ctx.stdout, '')
+                        if force:
+                            self.assertEqual(ctx.stderr, '')
+                        else:
+                            self.assertIn('missing.yaml', ctx.stderr)
+
+    def test_directories_and_list_files(self):
+        workspace = {
+            'ignored/drop.yaml': 'key: value  \n',
+            'ignored/keep.yaml': 'key: value  \n',
+            'included.yaml': 'key: value  \n',
+        }
+        conf = ('ignore: [ignored/*, "!ignored/keep.yaml"]\n'
+                'rules: {trailing-spaces: enable}\n')
+        with temp_workspace(workspace):
+            for flags in ((), ('--force-exclude',),
+                          ('-d', conf + 'force-exclude: true\n')):
+                for directory in ('ignored', 'ignored/'):
+                    with self.subTest(flags=flags, directory=directory):
+                        args = ('-d', conf, *flags, directory, 'included.yaml')
+                        with RunContext(self) as ctx:
+                            cli.run(('--list-files', *args))
+                        self.assertEqual(ctx.returncode, 0)
+                        self.assertEqual(ctx.stderr, '')
+                        self.assertEqual(
+                            ctx.stdout.splitlines(),
+                            ['ignored/keep.yaml', 'included.yaml'])
+                        with RunContext(self) as ctx:
+                            cli.run(('-f', 'parsable', *args))
+                        self.assertEqual(ctx.returncode, 1)
+                        self.assertEqual(ctx.stderr, '')
+                        self.assertEqual(
+                            [line.split(':')[0]
+                             for line in ctx.stdout.splitlines()],
+                            ['ignored/keep.yaml', 'included.yaml'])
+
+    def test_explicit_file_overrides_directory_ignore(self):
+        workspace = {'generated/bad.yaml': 'key: value  \n'}
+        conf = ('ignore: generated/\n'
+                'rules: {trailing-spaces: enable}\n')
+        with temp_workspace(workspace):
+            for path in ('generated/bad.yaml', './generated/bad.yaml'):
+                for force in (False, True):
+                    with self.subTest(path=path, force=force):
+                        flags = ('--force-exclude',) if force else ()
+                        with RunContext(self) as ctx:
+                            cli.run(('-d', conf, *flags, path))
+                        self.assertEqual(ctx.returncode, 0 if force else 1)
+                        self.assertEqual(ctx.stderr, '')
+                        self.assertEqual(bool(ctx.stdout), not force)
+            with RunContext(self) as ctx:
+                cli.run(('-d', conf, 'generated'))
+            self.assertEqual(ctx.returncode, 0)
+            self.assertEqual(ctx.stdout, '')
+            self.assertEqual(ctx.stderr, '')
+
+    def test_all_explicit_files_excluded(self):
+        with temp_workspace({'ignored.yaml': 'key: value  \n'}):
+            for flags in ((), ('--list-files',)):
+                with self.subTest(flags=flags):
+                    with RunContext(self) as ctx:
+                        cli.run(('--force-exclude', '-d',
+                                 'ignore: ignored.yaml', *flags,
+                                 './ignored.yaml'))
+                    self.assertEqual(ctx.returncode, 0)
+                    self.assertEqual(ctx.stdout, '')
+                    self.assertEqual(ctx.stderr, '')
 
 
 class CommandLineConfigTestCase(unittest.TestCase):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -833,6 +833,7 @@ class IgnoreConfigTestCase(unittest.TestCase):
                     '    ignore: file-at-root.yaml\n')
 
         sys.stdout = StringIO()
+        sys.stderr = StringIO()
         with self.assertRaises(SystemExit):
             cli.run(('-f', 'parsable', 'file.dont-lint-me.yaml',
                      'file-at-root.yaml'))
@@ -840,6 +841,28 @@ class IgnoreConfigTestCase(unittest.TestCase):
             sys.stdout.getvalue().strip(),
             'file-at-root.yaml:4:17: [error] trailing spaces (trailing-spaces)'
         )
+        self.assertIn('file.dont-lint-me.yaml', sys.stderr.getvalue())
+        self.assertIn('ignore list', sys.stderr.getvalue())
+        sys.stderr = sys.__stderr__
+
+    def test_run_with_ignore_on_ignored_dir(self):
+        path = os.path.join(self.wd, '.yamllint')
+        with open(path, 'w', encoding='utf_8') as f:
+            f.write('ignore: ign-dup\n'
+                    'rules:\n'
+                    '  trailing-spaces: enable\n')
+
+        sys.stdout = StringIO()
+        sys.stderr = StringIO()
+        with self.assertRaises(SystemExit):
+            cli.run(('-f', 'parsable', 'ign-dup', 'file-at-root.yaml'))
+        self.assertEqual(
+            sys.stdout.getvalue().strip(),
+            'file-at-root.yaml:4:17: [error] trailing spaces (trailing-spaces)'
+        )
+        self.assertIn('ign-dup', sys.stderr.getvalue())
+        self.assertIn('ignore list', sys.stderr.getvalue())
+        sys.stderr = sys.__stderr__
 
     def create_ignore_file(self, text, codec):
         path = os.path.join(self.wd, f'{codec}.ignore')

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -208,6 +208,21 @@ class SimpleConfigTestCase(unittest.TestCase):
             config.YamlLintConfig('rules:\n'
                                   '  colons: invalid\n')
 
+    def test_force_exclude(self):
+        self.assertFalse(config.YamlLintConfig('rules: {}').force_exclude)
+        for value in ('true', 'false'):
+            with self.subTest(value=value):
+                conf = config.YamlLintConfig(f'force-exclude: {value}')
+                self.assertEqual(conf.force_exclude, value == 'true')
+
+    def test_invalid_force_exclude(self):
+        for value in ('null', '0', '1', '"true"', '[]', '{}'):
+            with self.subTest(value=value):
+                with self.assertRaisesRegex(
+                        config.YamlLintConfigError,
+                        'invalid config: force-exclude should be a boolean'):
+                    config.YamlLintConfig(f'force-exclude: {value}')
+
     def test_invalid_ignore(self):
         with self.assertRaisesRegex(
                 config.YamlLintConfigError,
@@ -386,6 +401,20 @@ class ExtendedConfigTestCase(unittest.TestCase):
 
         self.assertEqual(c.rules['colons']['max-spaces-before'], 0)
         self.assertEqual(c.rules['colons']['max-spaces-after'], 1)
+
+    def test_extended_force_exclude(self):
+        for base_value in ('true', 'false'):
+            with tempfile.NamedTemporaryFile('w', encoding='utf_8') as f:
+                f.write(f'force-exclude: {base_value}\n')
+                f.flush()
+                for override in ('', 'true', 'false'):
+                    with self.subTest(base=base_value, override=override):
+                        content = f'extends: {f.name}\n'
+                        if override:
+                            content += f'force-exclude: {override}\n'
+                        conf = config.YamlLintConfig(content)
+                        self.assertEqual(conf.force_exclude,
+                                         (override or base_value) == 'true')
 
     def test_extended_ignore_str(self):
         with tempfile.NamedTemporaryFile('w', encoding='utf_8') as f:
@@ -833,36 +862,17 @@ class IgnoreConfigTestCase(unittest.TestCase):
                     '    ignore: file-at-root.yaml\n')
 
         sys.stdout = StringIO()
-        sys.stderr = StringIO()
         with self.assertRaises(SystemExit):
             cli.run(('-f', 'parsable', 'file.dont-lint-me.yaml',
                      'file-at-root.yaml'))
         self.assertEqual(
             sys.stdout.getvalue().strip(),
+            'file.dont-lint-me.yaml:3:3: [error] duplication of key "key" '
+            'in mapping (key-duplicates)\n'
+            'file.dont-lint-me.yaml:4:17: [error] trailing spaces '
+            '(trailing-spaces)\n'
             'file-at-root.yaml:4:17: [error] trailing spaces (trailing-spaces)'
         )
-        self.assertIn('file.dont-lint-me.yaml', sys.stderr.getvalue())
-        self.assertIn('ignore list', sys.stderr.getvalue())
-        sys.stderr = sys.__stderr__
-
-    def test_run_with_ignore_on_ignored_dir(self):
-        path = os.path.join(self.wd, '.yamllint')
-        with open(path, 'w', encoding='utf_8') as f:
-            f.write('ignore: ign-dup\n'
-                    'rules:\n'
-                    '  trailing-spaces: enable\n')
-
-        sys.stdout = StringIO()
-        sys.stderr = StringIO()
-        with self.assertRaises(SystemExit):
-            cli.run(('-f', 'parsable', 'ign-dup', 'file-at-root.yaml'))
-        self.assertEqual(
-            sys.stdout.getvalue().strip(),
-            'file-at-root.yaml:4:17: [error] trailing spaces (trailing-spaces)'
-        )
-        self.assertIn('ign-dup', sys.stderr.getvalue())
-        self.assertIn('ignore list', sys.stderr.getvalue())
-        sys.stderr = sys.__stderr__
 
     def create_ignore_file(self, text, codec):
         path = os.path.join(self.wd, f'{codec}.ignore')

--- a/tests/test_linter.py
+++ b/tests/test_linter.py
@@ -36,6 +36,20 @@ class LinterTestCase(unittest.TestCase):
     def test_run_on_stream(self):
         linter.run(io.StringIO('hello'), self.fake_config())
 
+    def test_run_with_no_ignore(self):
+        conf = YamlLintConfig(
+            'ignore: ignored.yaml\n'
+            'rules:\n'
+            '  trailing-spaces: enable\n'
+            '  document-start: {ignore: ignored.yaml}\n')
+        source = 'key: value  \n'
+        self.assertEqual(list(linter.run(source, conf, 'ignored.yaml')), [])
+        problems = list(linter.run(source, conf, 'ignored.yaml',
+                                   no_ignore=True))
+        self.assertEqual([p.rule for p in problems], ['trailing-spaces'])
+        # Bypassing ignores for one call must not mutate the configuration.
+        self.assertEqual(list(linter.run(source, conf, 'ignored.yaml')), [])
+
     def test_run_on_int(self):
         self.assertRaises(TypeError, linter.run, 42, self.fake_config())
 

--- a/yamllint/cli.py
+++ b/yamllint/cli.py
@@ -27,12 +27,19 @@ from yamllint.linter import PROBLEM_LEVELS
 def find_files_recursively(items, conf):
     for item in items:
         if os.path.isdir(item):
+            if conf.is_file_ignored(item):
+                print(f'warning: ignoring {item!r}: it is on the ignore list',
+                      file=sys.stderr)
+                continue
             for root, _dirnames, filenames in os.walk(item):
                 for f in filenames:
                     filepath = os.path.join(root, f)
                     if (conf.is_yaml_file(filepath) and
                             not conf.is_file_ignored(filepath)):
                         yield filepath
+        elif conf.is_file_ignored(item):
+            print(f'warning: ignoring {item!r}: it is on the ignore list',
+                  file=sys.stderr)
         else:
             yield item
 
@@ -210,8 +217,7 @@ def run(argv=None):
 
     if args.list_files:
         for file in find_files_recursively(args.files, conf):
-            if not conf.is_file_ignored(file):
-                print(file)
+            print(file)
         sys.exit(0)
 
     max_level = 0

--- a/yamllint/cli.py
+++ b/yamllint/cli.py
@@ -27,20 +27,13 @@ from yamllint.linter import PROBLEM_LEVELS
 def find_files_recursively(items, conf):
     for item in items:
         if os.path.isdir(item):
-            if conf.is_file_ignored(item):
-                print(f'warning: ignoring {item!r}: it is on the ignore list',
-                      file=sys.stderr)
-                continue
             for root, _dirnames, filenames in os.walk(item):
                 for f in filenames:
                     filepath = os.path.join(root, f)
                     if (conf.is_yaml_file(filepath) and
                             not conf.is_file_ignored(filepath)):
                         yield filepath
-        elif conf.is_file_ignored(item):
-            print(f'warning: ignoring {item!r}: it is on the ignore list',
-                  file=sys.stderr)
-        else:
+        elif not conf.force_exclude or not conf.is_file_ignored(item):
             yield item
 
 
@@ -168,6 +161,9 @@ def run(argv=None):
                               help='custom configuration (as YAML source)')
     parser.add_argument('--list-files', action='store_true', dest='list_files',
                         help='list files to lint and exit')
+    parser.add_argument('--force-exclude', action='store_true',
+                        help='apply ignore patterns to explicitly specified '
+                             'files before opening them')
     parser.add_argument('-f', '--format',
                         choices=('parsable', 'standard', 'colored', 'github',
                                  'auto'),
@@ -212,6 +208,9 @@ def run(argv=None):
         print(e, file=sys.stderr)
         sys.exit(-1)
 
+    if args.force_exclude:
+        conf.force_exclude = True
+
     if conf.locale is not None:
         locale.setlocale(locale.LC_ALL, conf.locale)
 
@@ -226,7 +225,8 @@ def run(argv=None):
         filepath = file.removeprefix('./')
         try:
             with open(file, mode='rb') as f:
-                problems = linter.run(f, conf, filepath)
+                # File selection has already applied global ignore patterns.
+                problems = linter.run(f, conf, filepath, no_ignore=True)
         except OSError as e:
             print(e, file=sys.stderr)
             sys.exit(-1)

--- a/yamllint/config.py
+++ b/yamllint/config.py
@@ -31,6 +31,7 @@ class YamlLintConfig:
         assert (content is None) ^ (file is None)
 
         self.ignore = None
+        self.force_exclude = False
 
         self.yaml_files = GitIgnoreSpec.from_lines(
             ['*.yaml', '*.yml', '.yamllint'])
@@ -68,6 +69,8 @@ class YamlLintConfig:
                 base_config.rules[rule] = self.rules[rule]
 
         self.rules = base_config.rules
+
+        self.force_exclude = base_config.force_exclude
 
         if base_config.ignore is not None:
             self.ignore = base_config.ignore
@@ -125,6 +128,12 @@ class YamlLintConfig:
             else:
                 raise YamlLintConfigError(
                     'invalid config: ignore should contain file patterns')
+
+        if 'force-exclude' in conf:
+            if not isinstance(conf['force-exclude'], bool):
+                raise YamlLintConfigError(
+                    'invalid config: force-exclude should be a boolean')
+            self.force_exclude = conf['force-exclude']
 
         if 'yaml-files' in conf:
             if not (isinstance(conf['yaml-files'], list)

--- a/yamllint/linter.py
+++ b/yamllint/linter.py
@@ -216,15 +216,18 @@ def _run(buffer, conf, filepath):
         yield syntax_error
 
 
-def run(input, conf, filepath=None):
+def run(input, conf, filepath=None, *, no_ignore=False):
     """Lints a YAML source.
 
     Returns a generator of LintProblem objects.
 
     :param input: buffer, string or stream to read from
     :param conf: yamllint configuration object
+    :param no_ignore: bypass global ignore patterns, keeping rule-specific
+        ignores in effect
     """
-    if filepath is not None and conf.is_file_ignored(filepath):
+    if (not no_ignore and filepath is not None and
+            conf.is_file_ignored(filepath)):
         return ()
 
     if isinstance(input, (bytes, str)):


### PR DESCRIPTION
Imagine that I put "1.yml" on the ignore list. Then, if I invoke yamllint like this:

```sh
yamllint 1.yml 2.yml 3.yml 4.yml 5.yml 6.yml
```

Then, instead of linting 2-6, it will actually lint 1-6! Which seems almost certainly to be a bug, because other industry-standard tools such as [Prettier](https://prettier.io/) will correctly skip 1.yml.

The behavior occurs with both files and directories. I didn't bother opening an issue in favor of just fixing the bug myself in a pull request.

One other situation that I thought about was when the user does not know that "1.yml" is on the ignore list and types `yamllint 1.yml`, expecting it to find errors, but instead yamllint passes. This could lead the user to think that yamllint rules are turned off or yamllint is bugged in some way. To address this, I also decided to print a warning to standard error when this happens, to explicitly let the user know that the file is being skipped (as a quality of life feature). However, note that Prettier does not do this, so it might not be needed.