### PR TITLE
Fix TypeError crash in indentation rule on invalid YAML

### DIFF
--- a/tests/rules/test_indentation.py
+++ b/tests/rules/test_indentation.py
@@ -1705,6 +1705,17 @@ class IndentationTestCase(RuleTestCase):
                    '   moustache}}\n',
                    conf, problem1=(4, 8), problem2=(5, 4))
 
+    def test_unmatched_flow_mapping_end(self):
+        # Regression test for TypeError crash when an unmatched '}'
+        # produces a FlowMappingEndToken in a block context (issue #771)
+        conf = ('indentation: {spaces: consistent}\n'
+                'document-start: disable\n')
+        self.check('data:\n'
+                   '  config.alloy: |\n'
+                   '\n'
+                   '  }\n',
+                   conf, problem=(4, 3, 'syntax'))
+
 
 class ScalarIndentationTestCase(RuleTestCase):
     rule_id = 'indentation'

--- a/yamllint/rules/indentation.py
+++ b/yamllint/rules/indentation.py
@@ -339,7 +339,7 @@ def _check(conf, token, prev, next, nextnext, context):
                 not isinstance(token, yaml.ValueToken)):
             expected = detect_indent(expected, token)
 
-        if found_indentation != expected:
+        if expected is not None and found_indentation != expected:
             if expected < 0:
                 message = (f'wrong indentation: expected at least '
                            f'{found_indentation + 1}')


### PR DESCRIPTION
Fixes #771.

**Failing scenario:** Linting invalid YAML that contains an unmatched `}` inside a block context (e.g. after a block scalar `|`):

```yaml
data:
  config.alloy: |

  }
```

**Before:** yamllint crashes with:
```
TypeError: '<' not supported between instances of 'NoneType' and 'int'
```
at `yamllint/rules/indentation.py`, line 343.

**After:** yamllint reports the syntax error normally:
```
4:3  error  syntax error: expected <block end>, but found '}'  (syntax)
```

**Root cause:** PyYAML emits a `FlowMappingEndToken` for the stray `}` without a matching `FlowMappingStartToken`. The indentation rule reads `line_indent` from the stack's current parent, which is `None` for non-flow parents, then crashes comparing `None < 0`.

**Fix:** Guard the indentation comparison so it is skipped when `expected` is `None`. The syntax error is still reported by the syntax checker.

**Validation:** Full test suite passes (431 tests). A regression test is included.