### PR TITLE
linter: Report non-printable characters as a syntax error

### DIFF
--- a/tests/rules/test_quoted_strings.py
+++ b/tests/rules/test_quoted_strings.py
@@ -14,7 +14,6 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 from tests.common import RuleTestCase
-import yaml.reader
 
 from yamllint import config
 
@@ -549,18 +548,18 @@ class QuotedValuesTestCase(RuleTestCase):
         self.check('---\n'
                    'k1: \\u001b\n',
                    conf)
-        self.assertRaises(yaml.reader.ReaderError, self.check,
-                          '---\n'
-                          'k1: "\u001b"\n',
-                          conf)
-        self.assertRaises(yaml.reader.ReaderError, self.check,
-                          '---\n'
-                          "k1: '\u001b'\n",
-                          conf)
-        self.assertRaises(yaml.reader.ReaderError, self.check,
-                          '---\n'
-                          'k1: \u001b\n',
-                          conf)
+        # A raw (non-escaped) non-printable character is invalid YAML; it
+        # must be reported as a syntax error rather than raising a
+        # ReaderError.
+        self.check('---\n'
+                   'k1: "\u001b"\n',
+                   conf, problem=(2, 6, 'syntax'))
+        self.check('---\n'
+                   "k1: '\u001b'\n",
+                   conf, problem=(2, 6, 'syntax'))
+        self.check('---\n'
+                   'k1: \u001b\n',
+                   conf, problem=(2, 5, 'syntax'))
 
     def test_octal_values(self):
         conf = 'quoted-strings: {required: true}\n'

--- a/tests/test_syntax_errors.py
+++ b/tests/test_syntax_errors.py
@@ -33,6 +33,26 @@ class YamlLintTestCase(RuleTestCase):
                    'doc: ument\n'
                    '...\n', None, problem=(3, 1))
 
+    def test_non_printable_characters(self):
+        # PyYAML rejects non-printable characters (control characters such as
+        # NUL or DEL) with a ReaderError, which is a YAMLError but not a
+        # MarkedYAMLError. yamllint must report these as syntax errors instead
+        # of letting the exception escape.
+        self.check('---\n'
+                   'key: val\x00ue\n', None, problem=(2, 9))
+        self.check('---\n'
+                   'this is ok\n'
+                   'this has a \x01 control char\n', None, problem=(3, 12))
+        self.check('\x7f\n', None, problem=(1, 1))
+        # A bare non-printable character with no other content.
+        self.check('\x00', None, problem=(1, 1))
+        # Cosmetic rules still run on the printable lines preceding the error.
+        self.check('---\n'
+                   'trailing:   \n'
+                   'oops\x00\n', None,
+                   problem1=(2, 10, 'trailing-spaces'),
+                   problem2=(3, 5))
+
     def test_empty_flows(self):
         self.check('---\n'
                    '- []\n'

--- a/yamllint/linter.py
+++ b/yamllint/linter.py
@@ -182,6 +182,17 @@ def get_syntax_error(buffer):
                               'syntax error: ' + e.problem + ' (syntax)')
         problem.level = 'error'
         return problem
+    except yaml.reader.ReaderError as e:
+        # ReaderError is raised for non-printable characters (e.g. control
+        # characters such as NUL) before the parser produces position marks.
+        # It is a YAMLError but not a MarkedYAMLError, so derive the line and
+        # column from its flat position into the buffer.
+        line = buffer.count('\n', 0, e.position)
+        column = e.position - (buffer.rfind('\n', 0, e.position) + 1)
+        problem = LintProblem(line + 1, column + 1,
+                              'syntax error: ' + e.reason + ' (syntax)')
+        problem.level = 'error'
+        return problem
 
 
 def _run(buffer, conf, filepath):

--- a/yamllint/parser.py
+++ b/yamllint/parser.py
@@ -121,11 +121,13 @@ def comments_between_tokens(token1, token2):
 
 def token_or_comment_generator(buffer):
     try:
-        # BaseLoader() can already raise (e.g. a ReaderError on non-printable
-        # characters), so construct it inside the try too. Any such failure is
-        # surfaced separately as a syntax error by the linter.
         yaml_loader = yaml.BaseLoader(buffer)
+    except yaml.reader.ReaderError:
+        # Failures like ReaderError on non-printable characters are surfaced
+        # separately as a syntax error by the linter, so ignore them here.
+        return
 
+    try:
         prev = None
         curr = yaml_loader.get_token()
         while curr is not None:
@@ -140,7 +142,7 @@ def token_or_comment_generator(buffer):
             prev = curr
             curr = next
 
-    except (yaml.scanner.ScannerError, yaml.reader.ReaderError):
+    except yaml.scanner.ScannerError:
         pass
 
 

--- a/yamllint/parser.py
+++ b/yamllint/parser.py
@@ -120,9 +120,12 @@ def comments_between_tokens(token1, token2):
 
 
 def token_or_comment_generator(buffer):
-    yaml_loader = yaml.BaseLoader(buffer)
-
     try:
+        # BaseLoader() can already raise (e.g. a ReaderError on non-printable
+        # characters), so construct it inside the try too. Any such failure is
+        # surfaced separately as a syntax error by the linter.
+        yaml_loader = yaml.BaseLoader(buffer)
+
         prev = None
         curr = yaml_loader.get_token()
         while curr is not None:
@@ -137,7 +140,7 @@ def token_or_comment_generator(buffer):
             prev = curr
             curr = next
 
-    except yaml.scanner.ScannerError:
+    except (yaml.scanner.ScannerError, yaml.reader.ReaderError):
         pass
 
 


### PR DESCRIPTION
Linting a file that contains an unescaped non-printable character (a NUL byte, DEL, or another control char) crashes yamllint with a raw traceback instead of reporting a problem:

```
$ printf 'key: val\000ue\n' | yamllint -
...
yaml.reader.ReaderError: unacceptable character #x0000: special characters are not allowed
  in "<unicode string>", position 8
```

PyYAML raises `ReaderError` for these characters. It is a `YAMLError` but, unlike the scanner/parser errors yamllint already catches, not a `MarkedYAMLError`, so it slipped past `get_syntax_error()`. The same input also broke `token_or_comment_generator()`, because `BaseLoader()` raises during construction before any token is produced.

This is the embedded-special-character case that #703 deliberately left raising (it fixed the backslash-escaped variant for `quoted-strings`). I catch `ReaderError` in `get_syntax_error()` and compute its line/column from the flat buffer position, and tolerate it in the token generator the same way `ScannerError` is. The character is now reported as an ordinary syntax error, and cosmetic rules still run on the printable lines before it.

I updated the three `quoted-strings` cases that previously asserted the crash, and added tests in `tests/test_syntax_errors.py`. Full suite, flake8 and ruff pass.