### PR TITLE
truthy: Don't carry %YAML version into the next document

### DIFF
--- a/tests/rules/test_truthy.py
+++ b/tests/rules/test_truthy.py
@@ -186,6 +186,19 @@ class TruthyTestCase(RuleTestCase):
                    'boolean6: !!bool NO\n',
                    conf)
 
+    def test_explicit_yaml_version_does_not_leak_to_next_document(self):
+        conf = ('truthy: enable\n'
+                'document-start: disable\n')
+        # A %YAML directive only applies to the document it introduces. A
+        # following directive-less document (separated by '---', without
+        # '...') must be linted as YAML 1.1, where 'on' is truthy.
+        self.check('%YAML 1.2\n'
+                   '---\n'
+                   'on: 1\n'
+                   '---\n'
+                   'on: 2\n',
+                   conf, problem1=(5, 1))
+
     def test_check_keys_disabled(self):
         conf = ('truthy:\n'
                 '  allowed-values: []\n'

--- a/yamllint/rules/truthy.py
+++ b/yamllint/rules/truthy.py
@@ -168,6 +168,15 @@ def yaml_spec_version_for_document(context):
 def check(conf, token, prev, next, nextnext, context):
     if isinstance(token, yaml.tokens.DirectiveToken) and token.name == 'YAML':
         context['yaml_spec_version'] = token.value
+    elif isinstance(token, yaml.tokens.DocumentStartToken):
+        # A new document starts with this '---' marker. Its spec version is
+        # set by a directive, which always precedes the marker, so only forget
+        # the previous document's version when this document has no directive
+        # of its own -- otherwise the version would leak into a directive-less
+        # document separated by '---' (no '...' DocumentEndToken to reset it).
+        if not isinstance(prev, yaml.tokens.DirectiveToken):
+            context.pop('yaml_spec_version', None)
+        context.pop('bad_truthy_values', None)
     elif isinstance(token, yaml.tokens.DocumentEndToken):
         context.pop('yaml_spec_version', None)
         context.pop('bad_truthy_values', None)


### PR DESCRIPTION
The `truthy` rule reads a document's YAML version from its `%YAML` directive, but it only forgets that version on a `...` document-end marker. When documents are separated by `---` alone, the previous document's version leaks into the next one — which has no directive of its own and should fall back to YAML 1.1:

    %YAML 1.2
    ---
    on: 1
    ---
    on: 2

`on` in the second document is a 1.1 truthy value and should be flagged, but the leaked 1.2 version silently suppresses it.

I reset the cached version when a `---` marker starts a document that has no directive of its own (a directive always precedes the marker, so a document that declares one keeps it). Added a test for the 1.2 → directive-less case; the existing multi-document test still passes. flake8, ruff and the full unittest suite are green.