### PR TITLE
indentation: Don't crash on a closing flow token without an opening one

### DIFF
--- a/tests/rules/test_indentation.py
+++ b/tests/rules/test_indentation.py
@@ -1089,6 +1089,25 @@ class IndentationTestCase(RuleTestCase):
                    '  y, z\n'
                    ']\n', conf, problem=(3, 4))
 
+    def test_unmatched_flow_end(self):
+        # On invalid YAML, a closing flow token ('}' or ']') can appear with no
+        # matching opening one; PyYAML still emits the corresponding
+        # FlowMapping/FlowSequenceEndToken. yamllint must report the syntax
+        # error instead of crashing in the indentation rule.
+        # https://github.com/adrienverge/yamllint/issues/771
+        conf = ('indentation: {spaces: consistent}\n'
+                'document-start: disable\n')
+        self.check('data:\n'
+                   '  config.alloy: |\n'
+                   '\n'
+                   '  }\n', conf, problem=(4, 3, 'syntax'))
+        self.check('data:\n'
+                   '  config.alloy: |\n'
+                   '\n'
+                   '  ]\n', conf, problem=(4, 3, 'syntax'))
+        self.check('}\n', conf, problem=(1, 1, 'syntax'))
+        self.check(']\n', conf, problem=(1, 1, 'syntax'))
+
     def test_cleared_flows(self):
         # flow:
         #   [

--- a/yamllint/rules/indentation.py
+++ b/yamllint/rules/indentation.py
@@ -339,7 +339,13 @@ def _check(conf, token, prev, next, nextnext, context):
                 not isinstance(token, yaml.ValueToken)):
             expected = detect_indent(expected, token)
 
-        if found_indentation != expected:
+        # A closing flow token (']' or '}') is expected to align with the line
+        # that opened the collection, so `expected` is read from that opening
+        # token. On invalid YAML, PyYAML can emit a closing flow token with no
+        # matching opening token on the stack, leaving `expected` unset; skip
+        # the indentation check in that case and let the syntax error be
+        # reported instead of crashing.
+        if expected is not None and found_indentation != expected:
             if expected < 0:
                 message = (f'wrong indentation: expected at least '
                            f'{found_indentation + 1}')


### PR DESCRIPTION
Running yamllint on some invalid YAML crashes instead of reporting the syntax error:

```
$ printf 'data:\n  config.alloy: |\n\n  }\n' | yamllint -
...
  File "yamllint/rules/indentation.py", line 343, in _check
    if expected < 0:
TypeError: '<' not supported between instances of 'NoneType' and 'int'
```

A stray `}` (or `]`) makes PyYAML emit a closing flow token with no matching opening one. When that token is first on its line, the rule tries to align it with the line that opened the collection and reads `line_indent` from the parent on its stack — but here the parent is a block/root node whose `line_indent` is `None`, so `expected` becomes `None` and the `expected < 0` comparison blows up.

I skip the indentation check when `expected` is `None`, which only happens in this malformed case, so well-formed flows are unchanged and the syntax error is reported as usual.

Fixes #771.